### PR TITLE
Added a compile time check for features, reformatted code

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, strum_macros::Display, PartialEq)]
+pub enum RequestMethod {
+    GET,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    OPTIONS,
+    TRACE,
+    HEAD,
+    CONNECT,
+}


### PR DESCRIPTION
Added a compile-time check so that only one runtime feature can be enabled at a time.
Changed the header handling to use http::HeaderName instead of plain strings.
Refactored the runtime connection setup to make it more consistent across the different runtimes.
Moved the `RequestMethod` enum into its own file (request.rs).
Did some small fixes and general cleanup.