### PR TITLE
Add syntax highlighting to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ With Deboa you can:
 
 ## Install
 
-deboa = { version = "0.0.5" }
+`deboa = { version = "0.0.5" }`
 
 ## Features
 
@@ -36,7 +36,7 @@ deboa = { version = "0.0.5" }
 
 ### Serialize request amd deserialize response using json
 
-```
+```rust
 use deboa::Deboa;
 
 let api = Deboa::new("https://jsonplaceholder.typicode.com");
@@ -48,7 +48,7 @@ println!("posts: {:#?}", posts);
 
 ### Serialize request amd deserialize response using xml
 
-```
+```rust
 use deboa::Deboa;
 
 let api = Deboa::new("https://jsonplaceholder.typicode.com");
@@ -60,7 +60,7 @@ println!("posts: {:#?}", posts);
 
 ### Adding headers
 
-```
+```rust
 use deboa::Deboa;
 use http::header;
 
@@ -73,7 +73,7 @@ println!("posts: {:#?}", posts);
 
 ### Adding bearer auth
 
-```
+```rust
 use deboa::Deboa;
 use http::header;
 
@@ -86,7 +86,7 @@ println!("posts: {:#?}", posts);
 
 ### Adding basic auth
 
-```
+```rust
 use deboa::Deboa;
 use http::header;
 
@@ -99,7 +99,7 @@ println!("posts: {:#?}", posts);
 
 ### Change request base url
 
-```
+```rust
 use deboa::Deboa;
 
 let api = Deboa::new("https://jsonplaceholder.typicode.com");
@@ -111,7 +111,7 @@ println!("posts: {:#?}", posts);
 
 ### Adding middleware
 
-```
+```rust
 use deboa::{Deboa, DeboaMiddleware};
 
 struct MyMiddleware;

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ With Deboa you can:
 
 ## Install
 
-`deboa = { version = "0.0.5" }`
+```rust
+deboa = { version = "0.0.5" }
+```
 
 ## Features
 


### PR DESCRIPTION
Before:

<img width="723" height="622" alt="Screenshot 2025-08-25 at 10 43 02 AM" src="https://github.com/user-attachments/assets/b310cd54-7f10-47b1-a683-372bd4daaa81" />



After:
<img width="692" height="788" alt="Screenshot 2025-08-25 at 10 43 30 AM" src="https://github.com/user-attachments/assets/33b81e74-ddde-4d22-b5b4-5664d608f177" />
