### PR TITLE
Error handling, dependency fixes request body change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +706,7 @@ dependencies = [
 name = "deboa"
 version = "0.0.5"
 dependencies = [
+ "anyhow",
  "async-native-tls",
  "base64",
  "bytes",

--- a/deboa/Cargo.toml
+++ b/deboa/Cargo.toml
@@ -10,27 +10,29 @@ license = "GPL-3.0-or-later"
 keywords = ["http", "networking", "client", "fetch", "rest-client"]
 
 [features]
-default = ["tokio-rt", "http1", "middlewares", "json"]
+default = ["http1", "middlewares", "json", "tokio-rt"]
 middlewares = []
 http1 = []
 http2 = []
 json = ["dep:serde_json", "dep:serde"]
 xml = [ "dep:serde-xml-rust", "dep:serde"]
 msgpack = ["dep:rmp-serde", "dep:serde"]
-tokio-rt = []
+tokio-rt = ["dep:tokio"]
 smol-rt = [
     "dep:smol",
     "dep:smol-hyper",
     "dep:async-native-tls",
     "dep:smol-macros",
     "dep:macro_rules_attribute",
+    "dep:anyhow",
 ]
-compio-rt = ["dep:compio", "dep:cyper-core", "dep:async-native-tls"]
+compio-rt = ["dep:compio", "dep:cyper-core", "dep:async-native-tls", "dep:anyhow"]
 
 [dependencies]
+anyhow = { version = "1.0.99", optional = true }
 async-native-tls = { version = "0.5.0", optional = true }
 base64 = "0.22.1"
-bytes = "1.2"
+bytes = { version = "1.2", optional = false }
 compio = { version = "0.15.0", optional = true, features = ["macros"] }
 cyper-core = { version = "0.4.0", optional = true, features = ["client"] }
 http = "1"
@@ -55,7 +57,7 @@ smol-hyper = { version = "0.1.0", optional = true }
 smol-macros = { version = "0.1.1", optional = true }
 strum_macros = "0.27.0"
 thiserror = "2.0.16"
-tokio = { version = "1.43.0", features = ["full"] }
+tokio = { version = "1.43.0", features = ["full"], optional = true }
 url = "2.5.4"
 
 [dev-dependencies]

--- a/deboa/src/lib.rs
+++ b/deboa/src/lib.rs
@@ -444,7 +444,7 @@ impl Deboa {
             return Err(DeboaError::SerializationError { message: error.to_string() });
         }
 
-        self.body = Some(result.unwrap().into());
+        self.body = Some(result.unwrap());
 
         Ok(self)
     }
@@ -553,7 +553,7 @@ impl Deboa {
     /// ```
     ///
     pub fn set_text(&mut self, text: String) -> &mut Self {
-        self.body = Some(text.as_bytes().to_vec().into());
+        self.body = Some(text.as_bytes().to_vec());
         self
     }
 
@@ -936,8 +936,8 @@ impl Deboa {
         }
 
         let req = match &self.body {
-            Some(body) => builder.body(Full::new(body.clone())),
-            None => builder.body(Full::new(Bytes::new())),
+            Some(body) => builder.body(Full::new(Bytes::from_owner(body.clone()))),
+            None => builder.body(Full::new(Bytes::from_owner(Vec::new()))),
         };
 
         if let Err(err) = req {
@@ -952,9 +952,7 @@ impl Deboa {
         let request = req.unwrap();
 
         // We need sure that we do not reconstruct the request somewhere else in the code as it will lead to the headers deletion making a request invalid.
-        let res = sender
-            .send_request(request)
-            .await;
+        let res = sender.send_request(request).await;
 
         if let Err(err) = res {
             return Err(DeboaError::RequestError {

--- a/deboa/src/lib.rs
+++ b/deboa/src/lib.rs
@@ -553,7 +553,7 @@ impl Deboa {
     /// ```
     ///
     pub fn set_text(&mut self, text: String) -> &mut Self {
-        self.body = Some(text.as_bytes().to_vec());
+        self.body = Some(text.as_bytes().to_vec().into());
         self
     }
 
@@ -864,15 +864,17 @@ impl Deboa {
         let mut sender = {
             let (sender, conn) = runtimes::tokio::get_connection(&url).await?;
 
-            match conn.await {
-                Ok(_) => (),
-                Err(err) => {
-                    return Err(DeboaError::ConnectionError {
-                        host: url.to_string(),
-                        message: err.to_string(),
-                    });
-                }
-            };
+            tokio::spawn(async move {
+                match conn.await {
+                    Ok(_) => (),
+                    Err(_err) => {
+                        // return Err(DeboaError::ConnectionError {
+                        //     host: url.to_string(),
+                        //     message: err.to_string(),
+                        // });
+                    }
+                };
+            });
 
             sender
         };
@@ -934,8 +936,8 @@ impl Deboa {
         }
 
         let req = match &self.body {
-            Some(body) => builder.body(Full::new(Bytes::from_owner(body.clone()))),
-            None => builder.body(Full::new(Bytes::from_owner(Vec::new()))),
+            Some(body) => builder.body(Full::new(body.clone())),
+            None => builder.body(Full::new(Bytes::new())),
         };
 
         if let Err(err) = req {
@@ -947,8 +949,11 @@ impl Deboa {
             });
         }
 
+        let request = req.unwrap();
+
+        // We need sure that we do not reconstruct the request somewhere else in the code as it will lead to the headers deletion making a request invalid.
         let res = sender
-            .send_request(Request::new(http_body_util::Full::new(Bytes::from_owner(req.unwrap().into_body()))))
+            .send_request(request)
             .await;
 
         if let Err(err) = res {

--- a/deboa/src/runtimes/compio/mod.rs
+++ b/deboa/src/runtimes/compio/mod.rs
@@ -4,6 +4,7 @@
 use std::str::FromStr;
 
 use anyhow::Result;
+use bytes::Bytes;
 use cyper_core::{HttpStream, TlsBackend};
 #[cfg(feature = "http1")]
 use hyper::client::conn::http1::{Connection, SendRequest};
@@ -12,7 +13,12 @@ use hyper::client::conn::http2::{Connection, SendRequest};
 use hyper::Uri;
 use url::Url;
 
-pub async fn get_connection(url: &Url) -> Result<(SendRequest<String>, Connection<HttpStream, String>)> {
+pub async fn get_connection(
+    url: &Url,
+) -> Result<(
+    SendRequest<http_body_util::Full<Bytes>>,
+    Connection<HttpStream, http_body_util::Full<Bytes>>,
+)> {
     let uri = Uri::from_str(url.as_str()).unwrap();
 
     let stream = HttpStream::connect(uri, TlsBackend::default()).await?;

--- a/deboa/src/runtimes/smol/mod.rs
+++ b/deboa/src/runtimes/smol/mod.rs
@@ -13,7 +13,12 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use url::Url;
 
-pub async fn get_connection(url: &Url) -> Result<(SendRequest<String>, Connection<FuturesIo<SmolStream>, String>)> {
+pub async fn get_connection(
+    url: &Url,
+) -> Result<(
+    SendRequest<http_body_util::Full<bytes::Bytes>>,
+    Connection<FuturesIo<SmolStream>, http_body_util::Full<bytes::Bytes>>,
+)> {
     let host = url.host().expect("uri has no host");
     let io = {
         match url.scheme() {

--- a/deboa/src/runtimes/tokio/mod.rs
+++ b/deboa/src/runtimes/tokio/mod.rs
@@ -37,18 +37,14 @@ pub async fn get_connection(
 
     #[cfg(feature = "http1")]
     let result = hyper::client::conn::http1::handshake(io).await;
-    
+
     #[cfg(feature = "http1")]
     match result {
-        Ok(conn) => {
-            return Ok(conn);
-        },
-        Err(err) => {
-            return Err(DeboaError::ConnectionError {
-                host: host.to_string(),
-                message: err.to_string(),
-            });
-        },
+        Ok(conn) => Ok(conn),
+        Err(err) => Err(DeboaError::ConnectionError {
+            host: host.to_string(),
+            message: err.to_string(),
+        }),
     }
 
     #[cfg(feature = "http2")]

--- a/deboa/src/runtimes/tokio/mod.rs
+++ b/deboa/src/runtimes/tokio/mod.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 #![warn(rust_2018_idioms)]
 
+use bytes::Bytes;
 #[cfg(feature = "http1")]
 use hyper::client::conn::http1::{Connection, SendRequest};
 #[cfg(feature = "http2")]
@@ -11,7 +12,15 @@ use url::{Host, Url};
 
 use crate::DeboaError;
 
-pub async fn get_connection(url: &Url) -> Result<(SendRequest<String>, Connection<TokioIo<TcpStream>, String>), DeboaError> {
+pub async fn get_connection(
+    url: &Url,
+) -> Result<
+    (
+        SendRequest<http_body_util::Full<Bytes>>,
+        Connection<TokioIo<TcpStream>, http_body_util::Full<Bytes>>,
+    ),
+    DeboaError,
+> {
     let host = url.host().unwrap_or(Host::Domain("localhost"));
     let port = url.port().unwrap_or(80);
     let addr = format!("{host}:{port}");
@@ -28,16 +37,19 @@ pub async fn get_connection(url: &Url) -> Result<(SendRequest<String>, Connectio
 
     #[cfg(feature = "http1")]
     let result = hyper::client::conn::http1::handshake(io).await;
+    
     #[cfg(feature = "http1")]
-    if let Err(err) = result {
-        return Err(DeboaError::ConnectionError {
-            host: host.to_string(),
-            message: err.to_string(),
-        });
+    match result {
+        Ok(conn) => {
+            return Ok(conn);
+        },
+        Err(err) => {
+            return Err(DeboaError::ConnectionError {
+                host: host.to_string(),
+                message: err.to_string(),
+            });
+        },
     }
-
-    #[cfg(feature = "http1")]
-    return Ok(result.unwrap());
 
     #[cfg(feature = "http2")]
     let result = hyper::client::conn::http2::handshake(io).await;

--- a/deboa/src/tests/mod.rs
+++ b/deboa/src/tests/mod.rs
@@ -3,6 +3,7 @@ pub mod deboa_tests {
     use crate::DeboaError;
     #[cfg(feature = "middlewares")]
     use crate::{middlewares::DeboaMiddleware, response::DeboaResponse, Deboa};
+
     use http::{header, StatusCode};
     #[cfg(feature = "json")]
     use serde::{Deserialize, Serialize};
@@ -290,12 +291,14 @@ pub mod deboa_tests {
             body: "Some test to do".to_string(),
         };
 
+        api.add_header(header::CONTENT_TYPE, "application/json".to_string());
+        
         #[cfg(feature = "json")]
         let response = api.set_json(data)?.post("/posts").await?;
 
         #[cfg(not(feature = "json"))]
         let response = api.post("/posts").await?;
-
+        
         assert_eq!(response.status, StatusCode::CREATED);
 
         Ok(())
@@ -374,7 +377,7 @@ pub mod deboa_tests {
 
     async fn do_patch() -> Result<(), DeboaError> {
         #[cfg(feature = "json")]
-        let mut api = Deboa::new("https://jsonplaceholder.typicode.com");
+        let mut api: Deboa = Deboa::new("https://jsonplaceholder.typicode.com");
 
         #[cfg(not(feature = "json"))]
         let api = Deboa::new("https://jsonplaceholder.typicode.com");
@@ -539,7 +542,7 @@ pub mod deboa_tests {
 
         let _ = api.set_json(data);
 
-        assert_eq!(api.body, Some("{\"id\":1,\"title\":\"Test\",\"body\":\"Some test to do\"}".to_string()));
+        assert_eq!(api.body, Some(b"{\"id\":1,\"title\":\"Test\",\"body\":\"Some test to do\"}".to_vec()));
     }
 
     #[cfg(feature = "json")]
@@ -644,7 +647,7 @@ pub mod deboa_tests {
 
         api.set_text("test".to_string());
 
-        assert_eq!(api.body, Some("test".to_string()));
+        assert_eq!(api.body, Some(b"test".to_vec()));
     }
 
     #[test]

--- a/deboa/src/tests/mod.rs
+++ b/deboa/src/tests/mod.rs
@@ -292,13 +292,13 @@ pub mod deboa_tests {
         };
 
         api.add_header(header::CONTENT_TYPE, "application/json".to_string());
-        
+
         #[cfg(feature = "json")]
         let response = api.set_json(data)?.post("/posts").await?;
 
         #[cfg(not(feature = "json"))]
         let response = api.post("/posts").await?;
-        
+
         assert_eq!(response.status, StatusCode::CREATED);
 
         Ok(())


### PR DESCRIPTION
Ive added error handling to connection timeouts, it automaticly returns an error instead of printing out the error in a different thread.
Ive also noticed a few mistakes in the dependencies of the different runtimes, which ive fixed by modifying the Cargo.toml to include anyhow for both compio and smol runtimes.
Ive also changed the request body to bytes, so we can send requests with msgpack. (I need a review on that so that to verify its correct, the checks ran fine for me but want a 2nd opinion)
Notice: Http2 is f*cked and we will probably need to fix that.