### PR TITLE
chore: ignore MacOs specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 deboa/target/
 .vscode
+.DS_Store


### PR DESCRIPTION
Remove files created automatically by MacOs.
