### PR TITLE
feat(glommio): add deboa-glommio, a binding for the glommio runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,17 +19,6 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -150,7 +139,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
- "concurrent-queue 2.5.0",
+ "concurrent-queue",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -163,9 +152,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
- "concurrent-queue 2.5.0",
- "fastrand 2.5.0",
- "futures-lite 2.6.1",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
  "pin-project-lite",
  "slab",
 ]
@@ -178,7 +167,7 @@ checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
  "async-lock",
  "blocking",
- "futures-lite 2.6.1",
+ "futures-lite",
 ]
 
 [[package]]
@@ -189,9 +178,9 @@ checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
  "cfg-if",
- "concurrent-queue 2.5.0",
+ "concurrent-queue",
  "futures-io",
- "futures-lite 2.6.1",
+ "futures-lite",
  "parking",
  "polling",
  "rustix",
@@ -231,7 +220,7 @@ checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
  "async-io",
  "blocking",
- "futures-lite 2.6.1",
+ "futures-lite",
 ]
 
 [[package]]
@@ -248,7 +237,7 @@ dependencies = [
  "blocking",
  "cfg-if",
  "event-listener",
- "futures-lite 2.6.1",
+ "futures-lite",
  "rustix",
 ]
 
@@ -333,6 +322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
+name = "bencher"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,15 +354,15 @@ dependencies = [
  "async-channel",
  "async-task",
  "futures-io",
- "futures-lite 2.6.1",
+ "futures-lite",
  "piper",
 ]
 
 [[package]]
 name = "buddy-alloc"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3240a4cb09cf0da6a51641bd40ce90e96ea6065e3a1adc46434029254bcc2d09"
+checksum = "ee741d62dcaf41ca303576ef890989ccb01d5dd77f8ce1a6d6c7846ab5d09efb"
 
 [[package]]
 name = "bumpalo"
@@ -392,12 +387,6 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-
-[[package]]
-name = "cache-padded"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
 name = "caramelo"
@@ -590,7 +579,7 @@ dependencies = [
  "compio-log",
  "compio-send-wrapper",
  "crossbeam-queue",
- "flume 0.12.0",
+ "flume",
  "futures-util",
  "io-uring",
  "libc",
@@ -601,7 +590,7 @@ dependencies = [
  "polling",
  "rustix",
  "smallvec",
- "socket2 0.6.5",
+ "socket2",
  "synchrony",
  "thin-cell",
  "windows-sys 0.61.2",
@@ -693,7 +682,7 @@ dependencies = [
  "libc",
  "once_cell",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "synchrony",
  "widestring",
  "windows-sys 0.61.2",
@@ -711,7 +700,7 @@ dependencies = [
  "compio-log",
  "compio-net",
  "compio-runtime",
- "flume 0.12.0",
+ "flume",
  "futures-util",
  "h3",
  "h3-datagram",
@@ -780,15 +769,6 @@ dependencies = [
  "native-tls",
  "pin-project-lite",
  "rustls",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -1148,7 +1128,7 @@ dependencies = [
  "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "futures-rustls",
- "glommio",
+ "glommio-ng",
  "hashbrown 0.17.1",
  "http",
  "http-body",
@@ -1583,18 +1563,12 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+dependencies = [
+ "getrandom 0.4.3",
+]
 
 [[package]]
 name = "faststr"
@@ -1638,23 +1612,11 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin",
-]
-
-[[package]]
-name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
+ "fastrand",
  "futures-core",
  "futures-sink",
  "spin",
@@ -1798,26 +1760,11 @@ checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 2.5.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -1948,36 +1895,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
-name = "glommio"
-version = "0.9.0"
+name = "glommio-ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8bc1fce949d18098dc0a4e861314e40351a0144ebf61e59bdb5254a2273b2"
+checksum = "2d6c9b99577dfaf726e575122b026fef3b57e2c39f03ae042460fdb5be7a1cc8"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
  "backtrace",
+ "bencher",
  "bitflags 2.13.1",
  "bitmaps",
  "buddy-alloc",
  "cc",
- "concurrent-queue 1.2.4",
+ "concurrent-queue",
  "crossbeam",
  "enclose",
- "flume 0.10.14",
- "futures-lite 1.13.0",
+ "flume",
+ "futures-lite",
  "intrusive-collections",
+ "io-uring",
  "lazy_static",
  "libc",
- "lockfree",
  "log",
- "nix 0.27.1",
+ "nix 0.30.1",
  "pin-project-lite",
  "rlimit",
+ "rustc_version",
  "scoped-tls",
  "scopeguard",
- "signal-hook 0.3.18",
+ "signal-hook",
  "sketches-ddsketch",
  "smallvec",
- "socket2 0.4.10",
+ "socket2",
  "tracing",
  "typenum",
 ]
@@ -2018,7 +1967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
 dependencies = [
  "bytes",
- "fastrand 2.5.0",
+ "fastrand",
  "futures-util",
  "http",
  "pin-project-lite",
@@ -2212,7 +2161,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2337,22 +2286,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "inventory"
@@ -2560,15 +2497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
-]
-
-[[package]]
-name = "lockfree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ee94b5ad113c7cb98c5a040f783d0952ee4fe100993881d1673c2cb002dd23"
-dependencies = [
- "owned-alloc",
 ]
 
 [[package]]
@@ -2791,15 +2719,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,12 +2746,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -3000,12 +2920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owned-alloc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fceb411f9a12ff9222c5f824026be368ff15dc2f13468d850c7d3f502205d6"
-
-[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3117,26 +3031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,7 +3049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand 2.5.0",
+ "fastrand",
  "futures-io",
 ]
 
@@ -3200,7 +3094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
- "concurrent-queue 2.5.0",
+ "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
@@ -3327,7 +3221,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "smol",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -3366,7 +3260,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3572,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "rlimit"
-version = "0.6.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc0bf25554376fd362f54332b8410a625c71f15445bca32ffdfdf4ec9ac91726"
+checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
 dependencies = [
  "libc",
 ]
@@ -3931,16 +3825,6 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
@@ -4004,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.1.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2ecae5fcf33b122e2e6bd520a57ccf152d2dde3b38c71039df1a6867264ee"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -4043,7 +3927,7 @@ dependencies = [
  "async-net",
  "async-process",
  "blocking",
- "futures-lite 2.6.1",
+ "futures-lite",
 ]
 
 [[package]]
@@ -4067,17 +3951,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "event-listener",
- "futures-lite 2.6.1",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
+ "futures-lite",
 ]
 
 [[package]]
@@ -4105,7 +3979,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "bumpalo",
  "bytes",
  "cfg-if",
@@ -4230,7 +4104,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.5.0",
+ "fastrand",
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
@@ -4386,7 +4260,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4733,7 +4607,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_yaml_ng",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.20",
  "time",
  "typetag",
@@ -4766,7 +4640,7 @@ dependencies = [
  "send_wrapper",
  "serde",
  "serde_yaml_ng",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.20",
  "time",
  "typetag",
@@ -4786,7 +4660,7 @@ dependencies = [
  "bytes",
  "clap",
  "env_logger",
- "futures-lite 2.6.1",
+ "futures-lite",
  "futures-rustls",
  "futures-util",
  "http",
@@ -4804,11 +4678,11 @@ dependencies = [
  "rustls",
  "serde",
  "serde_yaml_ng",
- "signal-hook 0.4.4",
+ "signal-hook",
  "smol",
  "smol-hyper",
  "smol-macros",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.20",
  "time",
  "typetag",
@@ -4844,7 +4718,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_yaml_ng",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.20",
  "time",
  "tokio",
@@ -4854,12 +4728,6 @@ dependencies = [
  "url",
  "vetis",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,37 +994,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deboa"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb779f386cdce549cd46db06617040fef67f4f9e57ee2f6fe01557fdf7280a8f"
-dependencies = [
- "async-lock",
- "base64",
- "bytes",
- "cookie",
- "futures",
- "hashbrown 0.17.1",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-body-utils",
- "hyper-util",
- "indexmap",
- "log",
- "minimime",
- "rand",
- "regex",
- "serde",
- "tackle",
- "thiserror 2.0.20",
- "time",
- "url",
- "urlencoding",
-]
-
-[[package]]
 name = "deboa-compio"
 version = "0.1.3"
 dependencies = [
@@ -1039,7 +1008,7 @@ dependencies = [
  "cookie",
  "criterion",
  "cyper-core",
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "deboa-h3",
  "deboa-test-utils",
  "easyhttpmock-vetis-compio",
@@ -1085,7 +1054,7 @@ checksum = "53d5d2b7104a58c2e3464fc2de1112bfcec4673a7d5d3c800924bdc040b397f1"
 dependencies = [
  "bytes",
  "ciborium",
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "flexbuffers",
  "futures",
  "http",
@@ -1110,7 +1079,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bddf7903fcdc45a863aa53a2d826661d3593441d7ed152634490e7033acc74d"
 dependencies = [
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "fory",
  "fory-core",
  "http",
@@ -1122,10 +1091,9 @@ version = "0.1.2"
 dependencies = [
  "async-lock",
  "base64",
- "blocking",
  "bytes",
  "cookie",
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "futures",
  "futures-rustls",
  "glommio-ng",
@@ -1164,7 +1132,7 @@ version = "0.1.1"
 dependencies = [
  "bytes",
  "compio-quic",
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "h3",
  "h3-quinn",
  "http",
@@ -1175,7 +1143,7 @@ dependencies = [
 name = "deboa-macros"
 version = "0.1.0"
 dependencies = [
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "deboa-extras",
  "http",
  "proc-macro2",
@@ -1196,7 +1164,7 @@ dependencies = [
  "caramelo",
  "cookie",
  "criterion",
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "deboa-h3",
  "deboa-test-utils",
  "easyhttpmock-vetis-smol",
@@ -1246,7 +1214,7 @@ dependencies = [
  "bytes",
  "caramelo",
  "ciborium",
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "deboa-extras",
  "deboa-fory",
  "deboa-macros",
@@ -1281,7 +1249,7 @@ dependencies = [
  "caramelo",
  "cookie",
  "criterion",
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "deboa-h3",
  "deboa-test-utils",
  "easyhttpmock-vetis-tokio",
@@ -4552,7 +4520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa2ece1260c82e1fc88e262b83de56e277336bb29ad68d8a81aa293438d460ab"
 dependencies = [
  "base64",
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "deboa-extras",
  "http",
  "serde",
@@ -4565,7 +4533,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c670bafa14b4445062d7eda7033be4a0334b6191935e73e0770677059d2a43"
 dependencies = [
- "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deboa",
  "deboa-extras",
  "http",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,32 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,7 +150,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 2.5.0",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -137,9 +163,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
+ "concurrent-queue 2.5.0",
+ "fastrand 2.5.0",
+ "futures-lite 2.6.1",
  "pin-project-lite",
  "slab",
 ]
@@ -152,7 +178,7 @@ checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
  "async-lock",
  "blocking",
- "futures-lite",
+ "futures-lite 2.6.1",
 ]
 
 [[package]]
@@ -163,9 +189,9 @@ checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
  "autocfg",
  "cfg-if",
- "concurrent-queue",
+ "concurrent-queue 2.5.0",
  "futures-io",
- "futures-lite",
+ "futures-lite 2.6.1",
  "parking",
  "polling",
  "rustix",
@@ -205,7 +231,7 @@ checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
 dependencies = [
  "async-io",
  "blocking",
- "futures-lite",
+ "futures-lite 2.6.1",
 ]
 
 [[package]]
@@ -222,7 +248,7 @@ dependencies = [
  "blocking",
  "cfg-if",
  "event-listener",
- "futures-lite",
+ "futures-lite 2.6.1",
  "rustix",
 ]
 
@@ -286,6 +312,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,9 +359,15 @@ dependencies = [
  "async-channel",
  "async-task",
  "futures-io",
- "futures-lite",
+ "futures-lite 2.6.1",
  "piper",
 ]
+
+[[package]]
+name = "buddy-alloc"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3240a4cb09cf0da6a51641bd40ce90e96ea6065e3a1adc46434029254bcc2d09"
 
 [[package]]
 name = "bumpalo"
@@ -339,6 +392,12 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cache-padded"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
 name = "caramelo"
@@ -531,7 +590,7 @@ dependencies = [
  "compio-log",
  "compio-send-wrapper",
  "crossbeam-queue",
- "flume",
+ "flume 0.12.0",
  "futures-util",
  "io-uring",
  "libc",
@@ -542,7 +601,7 @@ dependencies = [
  "polling",
  "rustix",
  "smallvec",
- "socket2",
+ "socket2 0.6.5",
  "synchrony",
  "thin-cell",
  "windows-sys 0.61.2",
@@ -634,7 +693,7 @@ dependencies = [
  "libc",
  "once_cell",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "synchrony",
  "widestring",
  "windows-sys 0.61.2",
@@ -652,7 +711,7 @@ dependencies = [
  "compio-log",
  "compio-net",
  "compio-runtime",
- "flume",
+ "flume 0.12.0",
  "futures-util",
  "h3",
  "h3-datagram",
@@ -701,7 +760,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1748b284601a5a267824b36894c7fc5e488b503f14a0a508f3b457ae018a451"
 dependencies = [
- "nix",
+ "nix 0.31.3",
  "once_cell",
  "slab",
  "synchrony",
@@ -721,6 +780,15 @@ dependencies = [
  "native-tls",
  "pin-project-lite",
  "rustls",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -802,6 +870,19 @@ checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1053,6 +1134,48 @@ dependencies = [
  "fory",
  "fory-core",
  "http",
+]
+
+[[package]]
+name = "deboa-glommio"
+version = "0.1.2"
+dependencies = [
+ "async-lock",
+ "base64",
+ "blocking",
+ "bytes",
+ "cookie",
+ "deboa 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "futures-rustls",
+ "glommio",
+ "hashbrown 0.17.1",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-body-utils",
+ "hyper-util",
+ "indexmap",
+ "log",
+ "macro_rules_attribute",
+ "minimime",
+ "mockall",
+ "rand",
+ "regex",
+ "rstest",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "smol-hyper",
+ "tackle",
+ "thiserror 2.0.20",
+ "time",
+ "url",
+ "urlencoding",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1359,6 +1482,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "enclose"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef75b364b1baff88ff28dc34e4c7c0ebd138abd76f4e58e24e37d9b7f54b8f1"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1583,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
@@ -1496,6 +1634,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
 ]
 
 [[package]]
@@ -1647,11 +1798,26 @@ checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand",
+ "fastrand 2.5.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -1770,10 +1936,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "glommio"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f8bc1fce949d18098dc0a4e861314e40351a0144ebf61e59bdb5254a2273b2"
+dependencies = [
+ "ahash 0.7.8",
+ "backtrace",
+ "bitflags 2.13.1",
+ "bitmaps",
+ "buddy-alloc",
+ "cc",
+ "concurrent-queue 1.2.4",
+ "crossbeam",
+ "enclose",
+ "flume 0.10.14",
+ "futures-lite 1.13.0",
+ "intrusive-collections",
+ "lazy_static",
+ "libc",
+ "lockfree",
+ "log",
+ "nix 0.27.1",
+ "pin-project-lite",
+ "rlimit",
+ "scoped-tls",
+ "scopeguard",
+ "signal-hook 0.3.18",
+ "sketches-ddsketch",
+ "smallvec",
+ "socket2 0.4.10",
+ "tracing",
+ "typenum",
+]
 
 [[package]]
 name = "granit-parser"
@@ -1811,7 +2018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10872b55cfb02a821b69dc7cf8dc6a71d6af25eb9a79662bec4a9d016056b3be"
 dependencies = [
  "bytes",
- "fastrand",
+ "fastrand 2.5.0",
  "futures-util",
  "http",
  "pin-project-lite",
@@ -2005,7 +2212,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2127,6 +2334,24 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
 ]
 
 [[package]]
@@ -2338,6 +2563,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ee94b5ad113c7cb98c5a040f783d0952ee4fe100993881d1673c2cb002dd23"
+dependencies = [
+ "owned-alloc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,6 +2640,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2680,15 @@ name = "minimime"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bcaa89828ea1e6ab547d9d61ae49f1f9336459b593f285ecc402af9152e16b2"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -2539,6 +2791,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2823,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2657,6 +2930,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,6 +2998,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owned-alloc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30fceb411f9a12ff9222c5f824026be368ff15dc2f13468d850c7d3f502205d6"
 
 [[package]]
 name = "page_size"
@@ -2829,6 +3117,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,7 +3155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand",
+ "fastrand 2.5.0",
  "futures-io",
 ]
 
@@ -2892,7 +3200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
- "concurrent-queue",
+ "concurrent-queue 2.5.0",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
@@ -3019,7 +3327,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "smol",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -3058,7 +3366,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3263,6 +3571,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0bf25554376fd362f54332b8410a625c71f15445bca32ffdfdf4ec9ac91726"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3309,6 +3626,12 @@ dependencies = [
  "syn 2.0.119",
  "unicode-ident",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -3608,6 +3931,16 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
@@ -3670,6 +4003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d2ecae5fcf33b122e2e6bd520a57ccf152d2dde3b38c71039df1a6867264ee"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,7 +4043,7 @@ dependencies = [
  "async-net",
  "async-process",
  "blocking",
- "futures-lite",
+ "futures-lite 2.6.1",
 ]
 
 [[package]]
@@ -3728,7 +4067,17 @@ dependencies = [
  "async-io",
  "async-lock",
  "event-listener",
- "futures-lite",
+ "futures-lite 2.6.1",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3756,7 +4105,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d971cc77a245ccf1756dbd1a87c3e7f709c0191464096510d43eec056d0f2c4f"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bumpalo",
  "bytes",
  "cfg-if",
@@ -3881,7 +4230,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand",
+ "fastrand 2.5.0",
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
@@ -4037,7 +4386,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4137,7 +4486,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4190,6 +4551,12 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -4366,7 +4733,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_yaml_ng",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "time",
  "typetag",
@@ -4399,7 +4766,7 @@ dependencies = [
  "send_wrapper",
  "serde",
  "serde_yaml_ng",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "time",
  "typetag",
@@ -4419,7 +4786,7 @@ dependencies = [
  "bytes",
  "clap",
  "env_logger",
- "futures-lite",
+ "futures-lite 2.6.1",
  "futures-rustls",
  "futures-util",
  "http",
@@ -4437,11 +4804,11 @@ dependencies = [
  "rustls",
  "serde",
  "serde_yaml_ng",
- "signal-hook",
+ "signal-hook 0.4.4",
  "smol",
  "smol-hyper",
  "smol-macros",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "time",
  "typetag",
@@ -4477,7 +4844,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_yaml_ng",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "time",
  "tokio",
@@ -4487,6 +4854,12 @@ dependencies = [
  "url",
  "vetis",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,11 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 panic = "abort"
+
+# The bindings depend on the *published* `deboa`, so a change to the core cannot
+# be built or tested locally without this. A patch rather than a path dependency
+# because `deboa-extras`, `vamo` and `deboa-fory` also depend on the published
+# crate — a path dep puts two versions of `deboa` in the graph and their traits
+# stop matching.
+[patch.crates-io]
+deboa = { path = "deboa" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "deboa",
     "deboa-h3",
     "deboa-compio",
+    "deboa-glommio",
     "deboa-macros",
     "deboa-smol",
     "deboa-test-utils",
@@ -24,6 +25,7 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 deboa = { version = "0.1.2" }
 deboa-compio = { path = "deboa-compio" }
+deboa-glommio = { path = "deboa-glommio" }
 deboa-h3 = { path = "deboa-h3", version = "^0.1.1" }
 deboa-extras = { version = ">= 0.0.9" }
 deboa-fory = { version = ">= 0.1.6" }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ deboa = { version = "0.1.0-beta.23" }
 
 - [tokio](https://github.com/tokio-rs/tokio)
 - [smol](https://github.com/smol-rs/smol)
+- [glommio](https://github.com/DataDog/glommio)
 
 ## Usage
 
@@ -75,6 +76,10 @@ It used to be the home of bora macro, which has been moved to vamo-macros crate.
 ### [deboa-compio](https://github.com/ararog/deboa/tree/develop/deboa-compio)
 
 Deboa implementation for compio runtime.
+
+### [deboa-glommio](https://github.com/ararog/deboa/tree/develop/deboa-glommio)
+
+Deboa implementation for glommio runtime.
 
 ### [deboa-smol](https://github.com/ararog/deboa/tree/develop/deboa-smol)
 

--- a/SPIKE-GLOMMIO.md
+++ b/SPIKE-GLOMMIO.md
@@ -1,0 +1,98 @@
+# Spike: glommio support for deboa
+
+**Run 2026-08-19, against deboa `c7ce9179`. Not pushed anywhere.**
+
+## Question
+
+Does deboa's abstraction admit a **per-core, `!Send`** runtime, or does it only
+look runtime-agnostic because tokio and smol are both `Send`-shaped?
+
+## Answer: yes, and it took a few hours
+
+`deboa-glommio` — copied from `deboa-smol` and ported — issues real requests on
+a bare `glommio::LocalExecutor`, no tokio or smol anywhere in the process:
+
+| | result |
+|---|---|
+| HTTP/1.1 plain, local MinIO | **200 OK** |
+| HTTP/1.1 + TLS, `https://example.com` | **200 OK** |
+| HTTP/2 + TLS (ALPN h2), `https://example.com` | **200 OK** |
+
+## Why it works
+
+The connection traits in `deboa/src/conn.rs` — `HttpConnection`,
+`HttpConnectionPool`, `HttpConnectionDispatcher`, `ProtoConnection` — use
+`impl Future` in trait position and carry **no `Send`, `Sync` or `'static`
+bounds**. That is the difference between this and, say, `iceberg::Catalog`,
+which is `#[async_trait]` and therefore boxes into `dyn Future + Send`.
+
+`deboa-compio` having gone first helps: compio is also completion-based and
+thread-per-core, so the abstraction had already met a runtime of this shape.
+
+## The port, in full
+
+Mechanical, and small:
+
+1. `rt/stream.rs` — `SmolStream` → `GlommioStream`; glommio's `TcpStream`
+   already implements `futures::io::{AsyncRead, AsyncWrite}`, so the enum and
+   its two impls carried over unchanged apart from the type.
+2. `rt/executor.rs` — `smol::spawn` → `glommio::spawn_local`. **The `Send`
+   bound on the impl was dropped**: hyper's `Executor` trait does not require
+   one, the smol and tokio bindings add it because their spawns do.
+3. `client/http/http1.rs`, `http2.rs` — same one-line spawn swap.
+   `smol_hyper::rt::FuturesIo` was reused as-is; it is generic over
+   `futures-io` and drags no runtime.
+4. `client/http/conn/stream/plain.rs` — dial through `glommio::net::TcpStream`.
+5. `cert.rs` — `smol::fs::read` → `std::fs::read` (certificate loading is
+   startup-time and blocking is honest there).
+6. `client/dns.rs` — see below.
+
+Dropped for the spike, not because they resist porting: websockets, HTTP/3
+(quinn), native-tls.
+
+## What deboa would need to change to take this upstream
+
+**One real blocker, and it is small.** `deboa/src/dns.rs`:
+
+```rust
+pub type DnsResolverFuture = Pin<Box<dyn Future<Output = Result<Vec<IpAddr>>> + Send>>;
+```
+
+The `+ Send` means a per-core resolver cannot use its runtime's blocking pool —
+glommio's `spawn_blocking` handle is `!Send`, as compio's presumably is. The
+spike calls `getaddrinfo` inline instead, which blocks the executor for the
+duration of a lookup. Acceptable for a spike; not for a merge.
+
+Fix options, in order of preference:
+
+1. Drop `+ Send` from the boxed future. Costs the other bindings nothing — a
+   `Send` future satisfies a `?Send` box.
+2. Make the future an associated type on `DnsResolver`, so each binding names
+   its own.
+
+Everything else compiled without touching a line of `deboa` core.
+
+## Recommendation
+
+Worth pursuing. Contributing `deboa-glommio` upstream is cheaper than finishing
+our own client (see `docs/http-client-roadmap.md`) and gets redirects,
+timeouts, cookies, caching, HTTP/3 and a maintained release cadence for free.
+
+Caveats to weigh, unchanged from the assessment:
+
+- deboa is `0.1.0-beta.23`, README warns of major API changes. Pin by rev, as
+  we do for glommio and barnabas.
+- deboa is client-only. `slipstream-http` still owns the hyper **server** and
+  the `object_store` `HttpConnector` facade either way.
+- `Client::default()` builds a `!Send` client; the `object_store` facade would
+  still be a channel in front of a per-core worker, exactly as it is now.
+
+## Reproducing
+
+```sh
+cd ~/projects/deboa      # this clone, outside the slipstream repo
+cargo run -p deboa-glommio --example spike --no-default-features \
+  --features http1,rust-tls,default-rustls-provider,default-rustls-verifier \
+  -- http://127.0.0.1:9000/minio/health/live
+H2=1 cargo run -p deboa-glommio --example spike -- https://example.com
+```

--- a/deboa-compio/src/client/dns.rs
+++ b/deboa-compio/src/client/dns.rs
@@ -1,6 +1,6 @@
 use compio::net::ToSocketAddrsAsync;
 use deboa::{
-    dns::{DnsResolver, DnsResolverFuture},
+    dns::DnsResolver,
     errors::{DeboaError::Dns, DnsError},
 };
 use rand::seq::SliceRandom;
@@ -11,23 +11,20 @@ use std::net::IpAddr;
 pub struct DefaultDnsResolver;
 
 impl DnsResolver for DefaultDnsResolver {
-    fn resolve(&self, host: String, port: u16) -> DnsResolverFuture {
-        let future = async move {
-            let hostname = format!("{}:{}", host, port);
-            let addrs = hostname
-                .to_socket_addrs_async()
-                .await;
-            if let Err(e) = addrs {
-                return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
-            };
-
-            let mut ips: Vec<IpAddr> = addrs
-                .unwrap()
-                .map(|addr| addr.ip())
-                .collect();
-            ips.shuffle(&mut rand::rng());
-            Ok(ips)
+    async fn resolve(&self, host: String, port: u16) -> deboa::Result<Vec<IpAddr>> {
+        let hostname = format!("{}:{}", host, port);
+        let addrs = hostname
+            .to_socket_addrs_async()
+            .await;
+        if let Err(e) = addrs {
+            return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
         };
-        Box::pin(future)
+
+        let mut ips: Vec<IpAddr> = addrs
+            .unwrap()
+            .map(|addr| addr.ip())
+            .collect();
+        ips.shuffle(&mut rand::rng());
+        Ok(ips)
     }
 }

--- a/deboa-glommio/.gitignore
+++ b/deboa-glommio/.gitignore
@@ -1,0 +1,2 @@
+target
+*.txt

--- a/deboa-glommio/Cargo.toml
+++ b/deboa-glommio/Cargo.toml
@@ -51,7 +51,6 @@ smol-hyper = { version = "0.1.0", default-features = false }
 [dependencies]
 async-lock = "3.4.2"
 base64 = "0.23.0"
-blocking = "1.6"
 bytes = { version = "1.11", default-features = false }
 cookie = { version = "0.18.1", default-features = false }
 deboa = { workspace = true }

--- a/deboa-glommio/Cargo.toml
+++ b/deboa-glommio/Cargo.toml
@@ -1,0 +1,87 @@
+[package]
+name = "deboa-glommio"
+version = "0.1.2"
+edition.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "A friendly rest client on top of hyper, on the glommio runtime."
+license.workspace = true
+keywords = ["http", "networking", "client", "fetch", "rest-client"]
+publish = false
+rust-version.workspace = true
+
+[features]
+default = ["http1", "http2", "rust-tls", "default-rustls-provider", "default-rustls-verifier"]
+
+rust-tls = ["dep:rustls", "dep:rustls-native-certs", "dep:futures-rustls", "dep:rustls-pki-types"]
+
+# Declared so the cfg is known and the error below is a clear message rather
+# than a wall of type errors. `async-native-tls` has no glommio binding — it
+# selects its runtime by feature (`runtime-tokio` / `runtime-smol`) — so this
+# cannot work until either that crate gains one or the TLS layer is abstracted.
+native-tls = []
+
+# Declared for the same reason: a clear message instead of a confusing failure.
+http3 = []
+websockets = []
+
+webpki-rustls-verifier = ["__webpki_rustls_verifier"]
+platform-rustls-verifier = ["__platform_rustls_verifier"]
+default-rustls-verifier = ["__webpki_rustls_verifier"]
+__webpki_rustls_verifier = ["dep:webpki-roots"]
+__platform_rustls_verifier = ["dep:rustls-platform-verifier"]
+
+no-provider = []
+aws-lc-rustls-provider = ["__rustls_aws_lc_rs"]
+ring-rustls-provider = ["__rustls_ring"]
+default-rustls-provider = ["__rustls_ring"]
+__rustls_aws_lc_rs = ["futures-rustls/aws-lc-rs"]
+__rustls_ring = ["futures-rustls/ring"]
+
+http1 = ["hyper/http1", "hyper-util/http1"]
+http2 = ["hyper/http2", "hyper-util/http2"]
+
+[dev-dependencies]
+http = "1"
+http-body-util = "0.1"
+hyper = { version = "1.10.1", features = ["server", "http1"] }
+smol-hyper = { version = "0.1.0", default-features = false }
+
+[dependencies]
+async-lock = "3.4.2"
+base64 = "0.23.0"
+blocking = "1.6"
+bytes = { version = "1.11", default-features = false }
+cookie = { version = "0.18.1", default-features = false }
+deboa = { workspace = true }
+futures = { version = "0.3.31", default-features = false, features = ["std"] }
+futures-rustls = { version = "0.26.0", optional = true, default-features = false }
+glommio = "0.9"
+hashbrown = "0.17.1"
+http = "1"
+http-body = "1"
+http-body-util = "0.1"
+hyper = { version = "1.10.1", features = ["client"], default-features = false }
+hyper-body-utils = { workspace = true, default-features = false }
+hyper-util = { version = "0.1.20", features = ["client", "client-legacy"], default-features = false }
+indexmap = "2.11.4"
+log = "0.4.32"
+macro_rules_attribute = { version = "0.2.2", default-features = false }
+minimime = "1.0.0"
+mockall = "0.15.0"
+rand = { version = "0.10.1", default-features = false }
+regex = { version = "1.12.4", default-features = false }
+rstest = "0.26.1"
+rustls = { version = "0.23.36", optional = true, default-features = false }
+rustls-native-certs = { version = "0.8.4", optional = true, default-features = false }
+rustls-pki-types = { version = "1.14.1", optional = true, default-features = false }
+rustls-platform-verifier = { version = "0.7.0", optional = true, default-features = false }
+serde = { version = "1.0.217", features = ["derive"] }
+smol-hyper = { version = "0.1.0", default-features = false }
+tackle = { version = "0.1.1" }
+thiserror = "2.0.17"
+time = { version = "0.3.51", default-features = false }
+url = "2.5.8"
+urlencoding = "2.1.3"
+webpki-roots = { version = "1.0.6", optional = true, default-features = false }

--- a/deboa-glommio/Cargo.toml
+++ b/deboa-glommio/Cargo.toml
@@ -57,7 +57,11 @@ cookie = { version = "0.18.1", default-features = false }
 deboa = { workspace = true }
 futures = { version = "0.3.31", default-features = false, features = ["std"] }
 futures-rustls = { version = "0.26.0", optional = true, default-features = false }
-glommio = "0.9"
+# `glommio-ng` is a republish of the community fork at github.com/glommio/glommio.
+# The canonical `glommio` crate is stuck at 0.9.0 (March 2024) and its vendored
+# liburing no longer compiles against current kernel headers. Renamed back to
+# `glommio` here so the source reads normally; see this crate's README.
+glommio = { package = "glommio-ng", version = "0.10" }
 hashbrown = "0.17.1"
 http = "1"
 http-body = "1"

--- a/deboa-glommio/README.md
+++ b/deboa-glommio/README.md
@@ -20,6 +20,28 @@ puzzle:
 - **`http3`** — needs a `quinn::Runtime` implementation for glommio.
 - **`websockets`** — not ported yet.
 
+## The glommio dependency
+
+This crate depends on [`glommio-ng`](https://crates.io/crates/glommio-ng),
+renamed back to `glommio` in the manifest so the source reads normally:
+
+```toml
+glommio = { package = "glommio-ng", version = "0.10" }
+```
+
+The canonical [`glommio`](https://crates.io/crates/glommio) crate is stuck at
+0.9.0 (March 2024), and its vendored liburing no longer compiles against
+current kernel headers — it fails with `invalid application of 'sizeof' to
+incomplete type 'struct open_how'` on any recent glibc. `glommio-ng` is a
+republish of the community fork at
+[github.com/glommio/glommio](https://github.com/glommio/glommio), which keeps
+io_uring and its dependencies current.
+
+**They are different crates and their types do not unify.** A library compiled
+against `glommio-ng` cannot accept an executor or socket from canonical
+`glommio`, and vice versa. If 0.10 is ever published under the canonical name
+this dependency becomes a one-line change and `glommio-ng` gets deprecated.
+
 ## Usage
 
 ```rust

--- a/deboa-glommio/README.md
+++ b/deboa-glommio/README.md
@@ -1,0 +1,60 @@
+# deboa-glommio
+
+## Description
+
+**deboa-glommio** is a deboa implementation for the [glommio](https://github.com/DataDog/glommio)
+runtime: thread-per-core, `io_uring`-backed, and single-threaded by
+construction. Its sockets and tasks are `!Send`, so a client built on it never
+leaves the core that opened its connections.
+
+## Status
+
+Supported: HTTP/1.1 and HTTP/2, plain and over TLS (`rust-tls`), connection
+pooling, and the shared deboa request/response surface.
+
+Not supported yet, and each fails with a clear `compile_error!` rather than a
+puzzle:
+
+- **`native-tls`** — `async-native-tls` selects its runtime by feature
+  (`runtime-tokio` / `runtime-smol`) and has no glommio binding.
+- **`http3`** — needs a `quinn::Runtime` implementation for glommio.
+- **`websockets`** — not ported yet.
+
+## Usage
+
+```rust
+use deboa::request::{get, FetchWith};
+use deboa_glommio::Client;
+
+fn main() {
+    glommio::LocalExecutorBuilder::default()
+        .make()
+        .unwrap()
+        .run(async {
+            let client = Client::default();
+            let response = get("https://example.com")
+                .unwrap()
+                .send_with(&client)
+                .await
+                .unwrap();
+            println!("{}", response.status());
+        });
+}
+```
+
+There is no `#[glommio::main]`-style attribute in the runtime, so the executor
+is built explicitly. `LocalExecutorPoolBuilder` runs one per core when you want
+the whole machine.
+
+## A note on DNS
+
+`getaddrinfo` is blocking in every runtime; the difference is where each one
+puts it. This binding uses the runtime-agnostic
+[`blocking`](https://crates.io/crates/blocking) thread pool rather than
+glommio's own `spawn_blocking`, because `deboa::dns::DnsResolverFuture` is
+`Pin<Box<dyn Future + Send>>` and glommio's blocking handle is bound to its
+local executor, hence `!Send`. compio's is a thread pool and therefore `Send`,
+which is why `deboa-compio` can use its runtime's own.
+
+Relaxing that boxed future to `?Send` would let this binding use glommio's pool
+and drop the extra threads. Nothing else in deboa needed changing.

--- a/deboa-glommio/README.md
+++ b/deboa-glommio/README.md
@@ -71,12 +71,12 @@ the whole machine.
 ## A note on DNS
 
 `getaddrinfo` is blocking in every runtime; the difference is where each one
-puts it. This binding uses the runtime-agnostic
-[`blocking`](https://crates.io/crates/blocking) thread pool rather than
-glommio's own `spawn_blocking`, because `deboa::dns::DnsResolverFuture` is
-`Pin<Box<dyn Future + Send>>` and glommio's blocking handle is bound to its
-local executor, hence `!Send`. compio's is a thread pool and therefore `Send`,
-which is why `deboa-compio` can use its runtime's own.
+puts it. This binding uses glommio's own `spawn_blocking`, so the work stays
+inside the runtime that owns the executor.
 
-Relaxing that boxed future to `?Send` would let this binding use glommio's pool
-and drop the extra threads. Nothing else in deboa needed changing.
+That is possible because `DnsResolver::resolve` returns `impl Future` rather
+than a boxed `dyn Future + Send`. The `Send` bound was more than a resolver can
+promise on every runtime: compio's `spawn_blocking` returns a `Send` future and
+satisfied it, glommio's handle is bound to its local executor and did not, so
+this binding originally had to pull in a second thread pool alongside glommio's
+to work around a bound it could not meet.

--- a/deboa-glommio/examples/simple.rs
+++ b/deboa-glommio/examples/simple.rs
@@ -29,7 +29,10 @@ fn main() {
             #[cfg(feature = "http2")]
             let request = get(url.as_str()).unwrap();
 
-            match request.send_with(&client).await {
+            match request
+                .send_with(&client)
+                .await
+            {
                 Ok(response) => println!("{}", response.status()),
                 Err(e) => {
                     eprintln!("request failed: {e:?}");

--- a/deboa-glommio/examples/simple.rs
+++ b/deboa-glommio/examples/simple.rs
@@ -19,7 +19,17 @@ fn main() {
         .expect("build glommio executor")
         .run(async move {
             let client = Client::default();
-            match get(url.as_str()).unwrap().send_with(&client).await {
+
+            // deboa defaults a request to HTTP/2; ask for 1.1 when this build
+            // has no http2 feature, or the dispatcher has no protocol to use.
+            #[cfg(not(feature = "http2"))]
+            let request = get(url.as_str())
+                .unwrap()
+                .version(http::Version::HTTP_11);
+            #[cfg(feature = "http2")]
+            let request = get(url.as_str()).unwrap();
+
+            match request.send_with(&client).await {
                 Ok(response) => println!("{}", response.status()),
                 Err(e) => {
                     eprintln!("request failed: {e:?}");

--- a/deboa-glommio/examples/simple.rs
+++ b/deboa-glommio/examples/simple.rs
@@ -1,0 +1,30 @@
+//! One request on a glommio executor.
+//!
+//! ```sh
+//! cargo run -p deboa-glommio --example simple -- https://example.com
+//! ```
+
+use deboa::request::{get, FetchWith};
+use deboa_glommio::Client;
+
+fn main() {
+    let url = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "https://example.com".to_string());
+
+    // glommio has no `#[main]` attribute, so the executor is explicit.
+    // `LocalExecutorPoolBuilder` runs one per core when you want the machine.
+    glommio::LocalExecutorBuilder::default()
+        .make()
+        .expect("build glommio executor")
+        .run(async move {
+            let client = Client::default();
+            match get(url.as_str()).unwrap().send_with(&client).await {
+                Ok(response) => println!("{}", response.status()),
+                Err(e) => {
+                    eprintln!("request failed: {e:?}");
+                    std::process::exit(1);
+                }
+            }
+        });
+}

--- a/deboa-glommio/src/cert.rs
+++ b/deboa-glommio/src/cert.rs
@@ -1,0 +1,353 @@
+//! Client certificate handling for secure connections.
+//!
+//! This module provides the `Identity` struct for working with client certificates
+//! in HTTPS connections, enabling mutual TLS (mTLS) authentication.
+//!
+//! It also provides the `Certificate` struct for working with CA certificates.
+
+#[cfg(feature = "native-tls")]
+use async_native_tls::{Certificate as NativeCertificate, Identity as NativeIdentity};
+#[cfg(feature = "native-tls")]
+use deboa::cert::IdentityNativeExt;
+use deboa::cert::{Certificate as _, CertificateExt, ContentEncoding, IdentityExt};
+#[cfg(feature = "rust-tls")]
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+/// Represents a client certificate and its associated data for mutual TLS authentication.
+///
+/// `Identity` encapsulates the client certificate, its password.
+/// It's used to authenticate the client to the server during the
+/// TLS handshake.
+///
+/// # Examples
+///
+/// ```igmore
+/// use deboa::cert::Identity;
+///
+/// // Load a DER encoded PKCS#12 archive from a slice of bytes using a password
+/// let cert = Identity::from_pkcs12(
+///     &[1, 2, 3],
+///     Some("cert-password".to_string()),
+/// );
+///
+/// // Load a DER encoded certificate and key from a slice of bytes
+/// let cert_with_ca = Identity::from_pkcs8(
+///     &[1, 2, 3],
+///     &[4, 5, 6],
+///     ContentEncoding::DER,
+/// );
+///
+/// ```
+#[derive(Debug, Clone)]
+pub struct DeboaIdentity {
+    cert: Vec<u8>,
+    key: Option<Vec<u8>>,
+    #[allow(unused)]
+    password: Option<String>,
+    #[allow(unused)]
+    encoding: Option<ContentEncoding>,
+}
+
+/// Type alias for backward compatibility
+pub type Identity = DeboaIdentity;
+/// Type alias for backward compatibility
+pub type Certificate = DeboaCertificate;
+
+#[cfg(feature = "native-tls")]
+/// Implementation of the Identity struct
+impl IdentityNativeExt for DeboaIdentity {
+    /// Load a DER encoded PKCS#12 archive from a slice of bytes
+    ///
+    /// # Arguments
+    ///
+    /// * `bundle` - The DER encoded PKCS#12 archive.
+    /// * `password` - The password for the PKCS#12 archive.
+    ///
+    /// # Returns
+    ///
+    /// * `Identity` - The new Identity instance.
+    ///
+    fn from_pkcs12(bundle: &[u8], password: Option<String>) -> Self {
+        DeboaIdentity { cert: bundle.to_vec(), key: None, password, encoding: None }
+    }
+
+    /// Load a DER encoded PKCS#12 archive from a file
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - The path to the DER encoded PKCS#12 archive.
+    /// * `password` - The password for the PKCS#12 archive.
+    ///
+    /// # Returns
+    ///
+    /// * `Identity` - The new Identity instance.
+    ///
+    async fn from_pkcs12_file(file: &str, password: Option<String>) -> std::io::Result<Self> {
+        let data = std::fs::read(file)?;
+        Ok(DeboaIdentity { cert: data, key: None, password, encoding: None })
+    }
+}
+
+impl deboa::cert::Identity for DeboaIdentity {
+    fn cert(&self) -> &Vec<u8> {
+        &self.cert
+    }
+
+    fn ket(&self) -> &Option<Vec<u8>> {
+        &self.key
+    }
+
+    fn encoding(&self) -> &Option<ContentEncoding> {
+        &self.encoding
+    }
+}
+
+impl IdentityExt for DeboaIdentity {
+    /// Load DER encoded certificate and key from a slice of bytes
+    ///
+    /// # Arguments
+    ///
+    /// * `cert` - The DER encoded certificate.
+    /// * `key` - The DER encoded PKCS8 private key.
+    /// * `encoding` - The encoding of the certificate and key.
+    ///
+    /// # Returns
+    ///
+    /// * `Identity` - The new Identity instance.
+    fn from_pkcs8(cert: &[u8], key: &[u8], encoding: ContentEncoding) -> Self {
+        DeboaIdentity {
+            cert: cert.to_vec(),
+            key: Some(key.to_vec()),
+            password: None,
+            encoding: Some(encoding),
+        }
+    }
+
+    /// Load DER encoded certificate and key from files
+    ///
+    /// # Arguments
+    ///
+    /// * `cert` - The path to the DER encoded certificate.
+    /// * `key` - The path to the DER encoded PKCS8 private key.
+    /// * `encoding` - The encoding of the certificate and key.
+    ///
+    /// # Returns
+    ///
+    /// * `Identity` - The new Identity instance.
+    ///
+    async fn from_pkcs8_file(
+        cert: &str,
+        key: &str,
+        encoding: ContentEncoding,
+    ) -> std::io::Result<Self> {
+        let cert = std::fs::read(cert)?;
+        let key = std::fs::read(key)?;
+        Ok(DeboaIdentity { cert, key: Some(key), password: None, encoding: Some(encoding) })
+    }
+}
+
+#[cfg(feature = "rust-tls")]
+impl TryFrom<&DeboaIdentity> for (CertificateDer<'static>, PrivateKeyDer<'static>) {
+    type Error = std::io::Error;
+
+    fn try_from(value: &DeboaIdentity) -> std::result::Result<Self, Self::Error> {
+        let cert = value.cert.clone();
+        let key = value
+            .key
+            .as_ref()
+            .unwrap()
+            .clone();
+
+        let pair = match value.encoding {
+            Some(ContentEncoding::DER) => {
+                let cert = CertificateDer::from(cert);
+
+                let key = PrivateKeyDer::try_from(key);
+                if key.is_err() {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "Invalid certificate",
+                    ));
+                }
+                (cert, key.unwrap())
+            }
+            Some(ContentEncoding::PEM) => {
+                use rustls_pki_types::pem::PemObject;
+
+                let cert = CertificateDer::from_pem_slice(&cert);
+                if let Err(e) = cert {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Invalid certificate: {}", e),
+                    ));
+                }
+
+                let key = PrivateKeyDer::from_pem_slice(&key);
+                if let Err(e) = key {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Invalid certificate: {}", e),
+                    ));
+                }
+                (cert.unwrap(), key.unwrap())
+            }
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid certificate",
+                ));
+            }
+        };
+
+        Ok(pair)
+    }
+}
+
+#[cfg(feature = "native-tls")]
+impl TryFrom<&DeboaIdentity> for NativeIdentity {
+    type Error = std::io::Error;
+
+    fn try_from(value: &DeboaIdentity) -> std::result::Result<Self, Self::Error> {
+        let identity = if let Some(password) = &value.password {
+            let identity = NativeIdentity::from_pkcs12(&value.cert, password);
+            if identity.is_err() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid certificate",
+                ));
+            }
+            identity.unwrap()
+        } else if let Some(key) = &value.key {
+            let identity = NativeIdentity::from_pkcs8(&value.cert, key);
+            if identity.is_err() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid certificate",
+                ));
+            }
+            identity.unwrap()
+        } else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "You need provide a password or a key",
+            ));
+        };
+
+        Ok(identity)
+    }
+}
+
+/// Represents a ca certificate.
+///
+/// # Examples
+///
+/// ```rust, no_run
+/// use deboa::cert::{CertificateExt as _, ContentEncoding};
+/// use deboa_glommio::cert::{DeboaCertificate};
+///
+/// // Load a DER encoded certificate from a file
+/// let cert = DeboaCertificate::from_file(
+///     "/path/to/cert.crt",
+///     ContentEncoding::DER,
+/// );
+///
+/// ```
+#[derive(Debug, Clone)]
+pub struct DeboaCertificate {
+    data: Vec<u8>,
+    encoding: ContentEncoding,
+}
+
+impl CertificateExt for DeboaCertificate {
+    /// Create certificate from slice of DER encoded bytes.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The client certificate data.
+    ///
+    /// # Returns
+    ///
+    /// * `Certificate` - The new Certificate instance.
+    ///
+    fn from_slice(data: &[u8], encoding: ContentEncoding) -> Self {
+        DeboaCertificate { data: data.to_vec(), encoding }
+    }
+
+    /// Create certificate from file of DER encoded file.
+    ///
+    /// # Arguments
+    ///
+    /// * `file` - The client certificate file path.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Certificate, std::io::Error>` - The new Certificate instance.
+    ///
+    async fn from_file(file: &str, encoding: ContentEncoding) -> std::io::Result<Self> {
+        let data = std::fs::read(file)?;
+        Ok(DeboaCertificate { data, encoding })
+    }
+}
+
+impl deboa::cert::Certificate for DeboaCertificate {
+    #[inline]
+    /// Allow get the client certificate path.
+    ///
+    /// # Returns
+    ///
+    /// * `&str` - The client certificate path.
+    ///
+    fn as_bytes(&self) -> &Vec<u8> {
+        &self.data
+    }
+}
+
+#[cfg(feature = "rust-tls")]
+impl TryFrom<&DeboaCertificate> for CertificateDer<'static> {
+    type Error = std::io::Error;
+
+    fn try_from(value: &DeboaCertificate) -> std::result::Result<Self, Self::Error> {
+        let cert = match value.encoding {
+            ContentEncoding::DER => CertificateDer::from(
+                value
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            ContentEncoding::PEM => {
+                use rustls_pki_types::pem::PemObject;
+
+                let result = CertificateDer::from_pem_slice(value.as_bytes());
+                if let Err(e) = result {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("Invalid certificate: {}", e),
+                    ));
+                }
+                result.unwrap()
+            }
+        };
+
+        Ok(cert)
+    }
+}
+
+#[cfg(feature = "native-tls")]
+impl TryFrom<&DeboaCertificate> for NativeCertificate {
+    type Error = std::io::Error;
+
+    fn try_from(value: &DeboaCertificate) -> std::result::Result<Self, Self::Error> {
+        let cert = match value.encoding {
+            ContentEncoding::DER => NativeCertificate::from_der(value.as_bytes()),
+            ContentEncoding::PEM => NativeCertificate::from_pem(value.as_bytes()),
+        };
+
+        if let Err(e) = cert {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("Invalid certificate: {}", e),
+            ));
+        }
+
+        Ok(cert.unwrap())
+    }
+}

--- a/deboa-glommio/src/client/dns.rs
+++ b/deboa-glommio/src/client/dns.rs
@@ -1,0 +1,51 @@
+use deboa::{
+    dns::{DnsResolver, DnsResolverFuture},
+    errors::{DeboaError::Dns, DnsError},
+};
+use rand::seq::SliceRandom;
+use std::net::IpAddr;
+
+#[derive(Default, Clone)]
+/// Default DNS resolver: `getaddrinfo` on glommio's blocking pool.
+///
+/// glommio has no async resolver — DNS is a blocking syscall, which is what
+/// tokio and smol also do internally, just behind their own pools.
+pub struct DefaultDnsResolver;
+
+impl DnsResolver for DefaultDnsResolver {
+    fn resolve(&self, host: String, port: u16) -> DnsResolverFuture {
+        let future = async move {
+            let hostname = format!("{}:{}", host, port);
+            // `getaddrinfo` is a blocking syscall, so it goes to a thread —
+            // as it does in every runtime, tokio and compio included.
+            //
+            // **Via the `blocking` crate rather than glommio's own pool**, and
+            // that is worth explaining: `DnsResolverFuture` is
+            // `Pin<Box<dyn Future + Send>>`, and glommio's `spawn_blocking`
+            // returns a handle bound to its local executor, which is `!Send`.
+            // compio's is a thread pool and therefore `Send`, which is why
+            // `deboa-compio` can use its runtime's own. `blocking::unblock`
+            // gives a `Send` future and is runtime-agnostic, so it fits the
+            // trait as written. If the boxed future ever loses its `Send`
+            // bound, this becomes `glommio::executor().spawn_blocking(..)` and
+            // the extra thread pool goes away.
+            let addrs = blocking::unblock(move || {
+                std::net::ToSocketAddrs::to_socket_addrs(&hostname[..])
+                    .map(|it| it.collect::<Vec<_>>())
+            })
+            .await;
+            if let Err(e) = addrs {
+                return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
+            };
+
+            let mut ips: Vec<IpAddr> = addrs
+                .unwrap()
+                .into_iter()
+                .map(|addr| addr.ip())
+                .collect();
+            ips.shuffle(&mut rand::rng());
+            Ok(ips)
+        };
+        Box::pin(future)
+    }
+}

--- a/deboa-glommio/src/client/dns.rs
+++ b/deboa-glommio/src/client/dns.rs
@@ -1,5 +1,5 @@
 use deboa::{
-    dns::{DnsResolver, DnsResolverFuture},
+    dns::DnsResolver,
     errors::{DeboaError::Dns, DnsError},
 };
 use rand::seq::SliceRandom;
@@ -13,39 +13,30 @@ use std::net::IpAddr;
 pub struct DefaultDnsResolver;
 
 impl DnsResolver for DefaultDnsResolver {
-    fn resolve(&self, host: String, port: u16) -> DnsResolverFuture {
-        let future = async move {
-            let hostname = format!("{}:{}", host, port);
-            // `getaddrinfo` is a blocking syscall, so it goes to a thread —
-            // as it does in every runtime, tokio and compio included.
-            //
-            // **Via the `blocking` crate rather than glommio's own pool**, and
-            // that is worth explaining: `DnsResolverFuture` is
-            // `Pin<Box<dyn Future + Send>>`, and glommio's `spawn_blocking`
-            // returns a handle bound to its local executor, which is `!Send`.
-            // compio's is a thread pool and therefore `Send`, which is why
-            // `deboa-compio` can use its runtime's own. `blocking::unblock`
-            // gives a `Send` future and is runtime-agnostic, so it fits the
-            // trait as written. If the boxed future ever loses its `Send`
-            // bound, this becomes `glommio::executor().spawn_blocking(..)` and
-            // the extra thread pool goes away.
-            let addrs = blocking::unblock(move || {
+    async fn resolve(&self, host: String, port: u16) -> deboa::Result<Vec<IpAddr>> {
+        let hostname = format!("{}:{}", host, port);
+        // `getaddrinfo` is a blocking syscall, so it goes to a thread — as it
+        // does in every runtime. glommio's own blocking pool can be used now
+        // that the trait no longer demands a `Send` future: the handle it
+        // returns is bound to this executor, which is exactly what a
+        // thread-per-core runtime wants and what the boxed `dyn Future + Send`
+        // made impossible.
+        let addrs = glommio::executor()
+            .spawn_blocking(move || {
                 std::net::ToSocketAddrs::to_socket_addrs(&hostname[..])
                     .map(|it| it.collect::<Vec<_>>())
             })
             .await;
-            if let Err(e) = addrs {
-                return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
-            };
-
-            let mut ips: Vec<IpAddr> = addrs
-                .unwrap()
-                .into_iter()
-                .map(|addr| addr.ip())
-                .collect();
-            ips.shuffle(&mut rand::rng());
-            Ok(ips)
+        if let Err(e) = addrs {
+            return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
         };
-        Box::pin(future)
+
+        let mut ips: Vec<IpAddr> = addrs
+            .unwrap()
+            .into_iter()
+            .map(|addr| addr.ip())
+            .collect();
+        ips.shuffle(&mut rand::rng());
+        Ok(ips)
     }
 }

--- a/deboa-glommio/src/client/http/conn/mod.rs
+++ b/deboa-glommio/src/client/http/conn/mod.rs
@@ -1,0 +1,213 @@
+//! Connection management for the Deboa HTTP client.
+//!
+//! This module provides the building blocks for managing HTTP connections,
+//! including connection pooling and protocol-specific implementations.
+//!
+//! # Architecture
+//!
+//! - [`http`]: Core HTTP protocol implementations (HTTP/1.1, HTTP/2)
+//! - [`pool`]: Connection pooling for efficient request handling
+//!
+//! # Features
+//!
+//! - Automatic connection pooling
+//! - Protocol negotiation (HTTP/1.1, HTTP/2)
+//! - Connection lifecycle management
+//! - Thread-safe connection handling
+//! ```
+use crate::cert::{DeboaCertificate, DeboaIdentity};
+#[cfg(feature = "http1")]
+use deboa::request::Http1Request;
+#[cfg(feature = "http2")]
+use deboa::request::Http2Request;
+use deboa::{
+    conn::{ConnectionConfig, HttpConnectionDispatcher, ProtoConnection},
+    errors::{DeboaError, RequestError},
+    response::DeboaResponse,
+    Result,
+};
+#[cfg(feature = "http3")]
+use deboa_h3::generic::Http3Request;
+use http::{Request, Version};
+use hyper_body_utils::HttpBody;
+use std::marker::PhantomData;
+
+/// Connection pooling for efficient HTTP connections.
+///
+/// This module provides connection pooling functionality to reuse connections
+/// across multiple requests, reducing latency and resource usage.
+///
+/// # Features
+///
+/// - Automatic connection reuse
+/// - Connection lifecycle management
+/// - Thread-safe operation
+/// - Configurable pool size (coming soon)
+pub mod pool;
+
+/// Stream module for runtime-specific stream implementations.
+///
+/// This module provides stream implementations for different runtimes (Tokio, Smol, etc.).
+pub(crate) mod stream;
+
+#[cfg(feature = "http1")]
+pub(crate) type Http1Connection = BaseHttpConnection<Http1Request, HttpBody, HttpBody>;
+#[cfg(feature = "http2")]
+pub(crate) type Http2Connection = BaseHttpConnection<Http2Request, HttpBody, HttpBody>;
+#[cfg(feature = "http3")]
+pub(crate) type Http3Connection = BaseHttpConnection<Http3Request, HttpBody, HttpBody>;
+
+/// Struct that represents the connection.
+///
+/// # Fields
+///
+/// * `sender` - The sender to use.
+pub struct BaseHttpConnection<Sender, ReqBody, ResBody> {
+    pub(crate) sender: Sender,
+    pub(crate) req_body: PhantomData<ReqBody>,
+    pub(crate) res_body: PhantomData<ResBody>,
+}
+
+impl<Sender, ReqBody, ResBody> BaseHttpConnection<Sender, ReqBody, ResBody> {
+    pub(crate) fn new(sender: Sender) -> Self {
+        Self { sender, req_body: PhantomData, res_body: PhantomData }
+    }
+}
+
+/// Enum that represents the connection type.
+///
+/// # Variants
+///
+/// * `Http1` - The HTTP/1.1 connection.
+/// * `Http2` - The HTTP/2 connection.
+/// * `Http3` - The HTTP/3 connection.
+pub enum DeboaConnection {
+    /// HTTP/1.1 connection
+    #[cfg(feature = "http1")]
+    Http1(Box<Http1Connection>),
+    /// HTTP/2 connection
+    #[cfg(feature = "http2")]
+    Http2(Box<Http2Connection>),
+    /// HTTP/3 connection
+    #[cfg(feature = "http3")]
+    Http3(Box<Http3Connection>),
+}
+
+impl DeboaConnection {
+    #[cfg(feature = "http1")]
+    /// Initialize a new HTTP/1.1 connection
+    pub fn http1(conn: Http1Connection) -> Self {
+        DeboaConnection::Http1(Box::new(conn))
+    }
+
+    #[cfg(feature = "http2")]
+    /// Initialize a new HTTP/2 connection
+    pub fn http2(conn: Http2Connection) -> Self {
+        DeboaConnection::Http2(Box::new(conn))
+    }
+
+    #[cfg(feature = "http3")]
+    /// Initialize a new HTTP/3 connection
+    pub fn http3(conn: Http3Connection) -> Self {
+        DeboaConnection::Http3(Box::new(conn))
+    }
+}
+
+impl HttpConnectionDispatcher for DeboaConnection {
+    /// Send a request through the connection.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL to send the request to.
+    /// * `request` - The request to send.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<DeboaResponse>` - The response from the server.
+    async fn send_request(&mut self, request: Request<HttpBody>) -> Result<DeboaResponse> {
+        match self {
+            #[cfg(feature = "http1")]
+            DeboaConnection::Http1(ref mut conn) => {
+                let (parts, body) = conn
+                    .sender
+                    .send_request(request)
+                    .await
+                    .map_err(|e| {
+                        DeboaError::Request(RequestError::Send { message: e.to_string() })
+                    })?
+                    .into_parts();
+
+                Ok(DeboaResponse::new(http::Response::from_parts(
+                    parts,
+                    HttpBody::from_incoming(body),
+                )))
+            }
+            #[cfg(feature = "http2")]
+            DeboaConnection::Http2(ref mut conn) => {
+                let (parts, body) = conn
+                    .sender
+                    .send_request(request)
+                    .await
+                    .map_err(|e| {
+                        DeboaError::Request(RequestError::Send { message: e.to_string() })
+                    })?
+                    .into_parts();
+
+                Ok(DeboaResponse::new(http::Response::from_parts(
+                    parts,
+                    HttpBody::from_incoming(body),
+                )))
+            }
+            #[cfg(feature = "http3")]
+            DeboaConnection::Http3(ref mut conn) => {
+                let response = conn
+                    .sender
+                    .send_request(request)
+                    .await
+                    .map_err(|e| {
+                        DeboaError::Request(RequestError::Send { message: e.to_string() })
+                    })?;
+
+                Ok(DeboaResponse::new(response))
+            }
+            #[allow(unreachable_patterns, clippy::needless_return)]
+            _ => {
+                return Err(DeboaError::UnsupportedProtocol);
+            }
+        }
+    }
+}
+
+/// Connection factory.
+pub struct ConnectionFactory {}
+
+impl ConnectionFactory {
+    /// Create a new connection.
+    pub async fn create_connection<'a>(
+        protocol: &Version,
+        config: &'a ConnectionConfig<'a, DeboaIdentity, DeboaCertificate>,
+    ) -> Result<DeboaConnection> {
+        let conn = match protocol {
+            #[cfg(feature = "http1")]
+            &Version::HTTP_11 => {
+                let conn = Http1Connection::connect(config).await?;
+                DeboaConnection::http1(conn)
+            }
+            #[cfg(feature = "http2")]
+            &Version::HTTP_2 => {
+                let conn = Http2Connection::connect(config).await?;
+                DeboaConnection::http2(conn)
+            }
+            #[cfg(all(feature = "http3", feature = "rust-tls"))]
+            &Version::HTTP_3 => {
+                let conn = Http3Connection::connect(&config).await?;
+                DeboaConnection::http3(conn)
+            }
+            _ => {
+                return Err(DeboaError::UnsupportedProtocol);
+            }
+        };
+
+        Ok(conn)
+    }
+}

--- a/deboa-glommio/src/client/http/conn/pool.rs
+++ b/deboa-glommio/src/client/http/conn/pool.rs
@@ -1,0 +1,111 @@
+use crate::{
+    cert::{DeboaCertificate, DeboaIdentity},
+    client::http::conn::{ConnectionConfig, ConnectionFactory, DeboaConnection},
+};
+use deboa::Result;
+use hashbrown::HashMap;
+use time::Duration;
+
+/// Struct that represents the HTTP connection pool.
+///
+/// # Fields
+///
+/// * `connections` - The connections.
+pub struct HttpConnectionPool {
+    max_idle_connections: u32,
+    keep_alive_duration: Duration,
+    connections: HashMap<String, DeboaConnection>,
+}
+
+impl AsMut<HttpConnectionPool> for HttpConnectionPool {
+    fn as_mut(&mut self) -> &mut HttpConnectionPool {
+        self
+    }
+}
+
+impl Default for HttpConnectionPool {
+    fn default() -> Self {
+        Self {
+            max_idle_connections: 5,
+            keep_alive_duration: Duration::minutes(5),
+            connections: HashMap::new(),
+        }
+    }
+}
+
+impl HttpConnectionPool {
+    /// Allow set max idle connections
+    ///
+    /// # Arguments
+    ///
+    /// * `max_idle_connections` - The max idle connections.
+    ///
+    pub fn set_max_idle_connections(&mut self, max_idle_connections: u32) {
+        self.max_idle_connections = max_idle_connections;
+    }
+
+    /// Allow set keep alive duration
+    ///
+    /// # Arguments
+    ///
+    /// * `keep_alive_duration` - The keep alive duration.
+    ///
+    pub fn set_keep_alive_duration(&mut self, keep_alive_duration: Duration) {
+        self.keep_alive_duration = keep_alive_duration;
+    }
+}
+
+impl deboa::conn::HttpConnectionPool for HttpConnectionPool {
+    type Identity = DeboaIdentity;
+    type Certificate = DeboaCertificate;
+    type ConnectionDispather = DeboaConnection;
+    type ConnectionCache = HashMap<String, DeboaConnection>;
+
+    fn new(max_idle_connections: u32, keep_alive_duration: Duration) -> Self {
+        Self { max_idle_connections, keep_alive_duration, connections: HashMap::new() }
+    }
+
+    #[inline]
+    fn connections(&self) -> &Self::ConnectionCache {
+        &self.connections
+    }
+
+    #[inline]
+    fn connection_count(&self) -> u32 {
+        self.connections
+            .len() as u32
+    }
+
+    async fn create_connection<'a>(
+        &'a mut self,
+        config: &ConnectionConfig<'a, Self::Identity, Self::Certificate>,
+    ) -> Result<&'a mut Self::ConnectionDispather> {
+        if self.max_idle_connections == 0 {
+            self.connections
+                .clear();
+        }
+
+        let host = config.host();
+        if self
+            .connections
+            .contains_key(host)
+        {
+            log::debug!("Connection already exists for {}, reusing.", host);
+            return Ok(self
+                .connections
+                .get_mut(host)
+                .unwrap());
+        }
+
+        log::debug!("Creating new connection for {}", host);
+        let connection =
+            ConnectionFactory::create_connection(config.protocol_version(), config).await?;
+
+        self.connections
+            .insert(host.to_string(), connection);
+        Ok(self
+            .connections
+            .get_mut(host)
+            .unwrap())
+    }
+}

--- a/deboa-glommio/src/client/http/conn/stream/mod.rs
+++ b/deboa-glommio/src/client/http/conn/stream/mod.rs
@@ -1,0 +1,7 @@
+pub(crate) mod plain;
+pub(crate) use plain::*;
+
+#[cfg(feature = "rust-tls")]
+pub(crate) mod tls;
+#[cfg(feature = "rust-tls")]
+pub(crate) use tls::*;

--- a/deboa-glommio/src/client/http/conn/stream/plain.rs
+++ b/deboa-glommio/src/client/http/conn/stream/plain.rs
@@ -1,0 +1,27 @@
+use crate::rt::stream::GlommioStream;
+use deboa::{
+    errors::{ConnectionError, DeboaError},
+    Result,
+};
+use glommio::net::TcpStream;
+use std::net::IpAddr;
+
+pub(crate) async fn create_stream(addr: IpAddr, host: &str, port: u16) -> Result<TcpStream> {
+    let tcp_stream = TcpStream::connect((addr, port)).await;
+    let tcp_stream = match tcp_stream {
+        Ok(tcp_stream) => tcp_stream,
+        Err(e) => {
+            return Err(DeboaError::Connection(ConnectionError::Tcp {
+                host: host.to_string(),
+                message: format!("Could not connect to server: {}", e),
+            }));
+        }
+    };
+
+    Ok(tcp_stream)
+}
+
+pub(crate) async fn plain_connection(addr: IpAddr, host: &str, port: u16) -> Result<GlommioStream> {
+    let stream = create_stream(addr, host, port).await?;
+    Ok(GlommioStream::Plain(stream))
+}

--- a/deboa-glommio/src/client/http/conn/stream/tls/mod.rs
+++ b/deboa-glommio/src/client/http/conn/stream/tls/mod.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "native-tls")]
+mod native;
+
+#[cfg(feature = "rust-tls")]
+mod rustls;
+
+#[cfg(feature = "rust-tls")]
+pub(crate) use rustls::*;
+
+#[cfg(feature = "native-tls")]
+pub(crate) use native::*;

--- a/deboa-glommio/src/client/http/conn/stream/tls/mod.rs
+++ b/deboa-glommio/src/client/http/conn/stream/tls/mod.rs
@@ -1,11 +1,9 @@
-#[cfg(feature = "native-tls")]
-mod native;
-
+// No `native` module: `native-tls` is rejected with a `compile_error!` in this
+// binding, because `async-native-tls` selects its runtime by feature and has no
+// glommio one. Declaring the module anyway would leave `cargo fmt` chasing a
+// file that does not exist.
 #[cfg(feature = "rust-tls")]
 mod rustls;
 
 #[cfg(feature = "rust-tls")]
 pub(crate) use rustls::*;
-
-#[cfg(feature = "native-tls")]
-pub(crate) use native::*;

--- a/deboa-glommio/src/client/http/conn/stream/tls/rustls.rs
+++ b/deboa-glommio/src/client/http/conn/stream/tls/rustls.rs
@@ -1,0 +1,213 @@
+use crate::{
+    cert::{DeboaCertificate, DeboaIdentity},
+    client::http::conn::stream::plain::create_stream,
+    rt::stream::GlommioStream,
+};
+use deboa::{
+    errors::{ConnectionError, DeboaError},
+    Result,
+};
+use futures_rustls::TlsConnector;
+use rustls::{pki_types::ServerName, ClientConfig};
+use rustls_pki_types::{CertificateDer, PrivateKeyDer};
+use std::{net::IpAddr, sync::Arc};
+
+pub(crate) async fn tls_connection<'a>(
+    ip: IpAddr,
+    host: &str,
+    port: u16,
+    identity: &'a Option<DeboaIdentity>,
+    certificate: &'a Option<DeboaCertificate>,
+    skip_server_verification: bool,
+    alpn: Vec<Vec<u8>>,
+) -> Result<GlommioStream> {
+    let socket = create_stream(ip, host, port).await?;
+    let config = setup_rust_tls(host, identity, certificate, skip_server_verification, alpn)?;
+    let connector = TlsConnector::from(Arc::new(config));
+    let hostname = ServerName::try_from(host.to_string());
+
+    if let Err(e) = hostname {
+        return Err(DeboaError::Connection(ConnectionError::Tls {
+            host: host.to_string(),
+            message: e.to_string(),
+        }));
+    }
+
+    let stream = connector
+        .connect(hostname.unwrap(), socket)
+        .await;
+
+    if let Err(e) = stream {
+        return Err(DeboaError::Connection(ConnectionError::Tls {
+            host: host.to_string(),
+            message: format!("Could not connect to server: {}", e),
+        }));
+    }
+
+    let stream = stream.unwrap();
+    Ok(GlommioStream::Tls(Box::new(stream)))
+}
+
+pub(crate) fn default_provider() -> Arc<rustls::crypto::CryptoProvider> {
+    #[cfg(feature = "__rustls_aws_lc_rs")]
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    #[cfg(feature = "__rustls_ring")]
+    let provider = rustls::crypto::ring::default_provider();
+    Arc::new(provider)
+}
+
+pub(crate) fn setup_rust_tls<'a>(
+    host: &str,
+    identity: &'a Option<DeboaIdentity>,
+    certificate: &'a Option<DeboaCertificate>,
+    skip_server_verification: bool,
+    alpn: Vec<Vec<u8>>,
+) -> Result<ClientConfig> {
+    let provider = default_provider();
+
+    if skip_server_verification {
+        use verify::SkipServerVerification;
+        let config = rustls::ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .expect("Failed to set TLS version")
+            .dangerous()
+            .with_custom_certificate_verifier(SkipServerVerification::new())
+            .with_no_client_auth();
+        return Ok(config);
+    }
+
+    #[cfg(feature = "__webpki_rustls_verifier")]
+    let config = {
+        let config = rustls::ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .expect("Failed to set TLS version");
+
+        let mut root_store =
+            rustls::RootCertStore { roots: webpki_roots::TLS_SERVER_ROOTS.to_vec() };
+        if let Some(ca) = certificate {
+            let cert = ca.try_into();
+            if let Err(e) = cert {
+                return Err(DeboaError::Connection(ConnectionError::Tls {
+                    host: host.to_string(),
+                    message: format!("Invalid CA certificate: {}", e),
+                }));
+            }
+
+            let result = root_store.add(cert.unwrap());
+            if let Err(e) = result {
+                return Err(DeboaError::Connection(ConnectionError::Tls {
+                    host: host.to_string(),
+                    message: format!("Could not add CA certificate to the store: {}", e),
+                }));
+            }
+
+            config.with_root_certificates(root_store)
+        } else {
+            config.with_root_certificates(root_store)
+        }
+    };
+
+    #[cfg(feature = "__platform_rustls_verifier")]
+    let config = {
+        use rustls_platform_verifier::Verifier;
+        let verifier = Verifier::new(provider).expect("Failed to create platform verifier");
+        rustls::ClientConfig::builder_with_provider(default_provider())
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .expect("Failed to set TLS version")
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(verifier))
+    };
+
+    let mut config = if let Some(id) = identity {
+        let pair = id.try_into();
+        if let Err(e) = pair {
+            return Err(DeboaError::Connection(ConnectionError::Tls {
+                host: host.to_string(),
+                message: format!("Invalid client identity: {}", e),
+            }));
+        }
+
+        let pair: (CertificateDer<'static>, PrivateKeyDer<'static>) = pair.unwrap();
+
+        config
+            .with_client_auth_cert(vec![pair.0], pair.1)
+            .expect("Failed to set client identity")
+    } else {
+        config.with_no_client_auth()
+    };
+
+    config.enable_early_data = true;
+
+    config.alpn_protocols = alpn;
+
+    Ok(config)
+}
+
+pub(crate) mod verify {
+    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    pub(crate) struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
+
+    impl SkipServerVerification {
+        pub(crate) fn new() -> Arc<Self> {
+            let provider = super::default_provider();
+            Arc::new(Self(provider))
+        }
+    }
+
+    impl rustls::client::danger::ServerCertVerifier for SkipServerVerification {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp: &[u8],
+            _now: UnixTime,
+        ) -> std::result::Result<rustls::client::danger::ServerCertVerified, rustls::Error>
+        {
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &rustls::DigitallySignedStruct,
+        ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
+        {
+            rustls::crypto::verify_tls12_signature(
+                message,
+                cert,
+                dss,
+                &self
+                    .0
+                    .signature_verification_algorithms,
+            )
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &rustls::DigitallySignedStruct,
+        ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
+        {
+            rustls::crypto::verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &self
+                    .0
+                    .signature_verification_algorithms,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            self.0
+                .signature_verification_algorithms
+                .supported_schemes()
+        }
+    }
+}

--- a/deboa-glommio/src/client/http/http1.rs
+++ b/deboa-glommio/src/client/http/http1.rs
@@ -66,8 +66,7 @@ impl ProtoConnection for Http1Connection {
         let (sender, conn) = result.unwrap();
 
         glommio::spawn_local(async move {
-            match conn.await
-            {
+            match conn.await {
                 Ok(_) => (),
                 Err(_err) => {}
             };

--- a/deboa-glommio/src/client/http/http1.rs
+++ b/deboa-glommio/src/client/http/http1.rs
@@ -1,0 +1,79 @@
+#[cfg(feature = "rust-tls")]
+use crate::alpn;
+#[cfg(feature = "rust-tls")]
+use crate::client::http::conn::stream::tls_connection;
+use crate::{
+    cert::{DeboaCertificate, DeboaIdentity},
+    client::http::conn::{stream::plain_connection, BaseHttpConnection, Http1Connection},
+};
+use deboa::{
+    conn::{ConnectionConfig, HttpConnection, ProtoConnection},
+    request::Http1Request,
+    Result,
+};
+use http::version::Version;
+use hyper::client::conn::http1::handshake;
+use hyper_body_utils::HttpBody;
+use smol_hyper::rt::FuturesIo;
+
+impl HttpConnection for Http1Connection {
+    type Sender = Http1Request;
+    fn sender(&mut self) -> &mut Self::Sender {
+        &mut self.sender
+    }
+}
+
+impl ProtoConnection for Http1Connection {
+    type ReqBody = HttpBody;
+    type ResBody = HttpBody;
+    type Connection = Http1Connection;
+    type Identity = DeboaIdentity;
+    type Certificate = DeboaCertificate;
+
+    #[inline]
+    fn protocol_version(&self) -> Version {
+        Version::HTTP_11
+    }
+
+    async fn connect<'a>(
+        config: &ConnectionConfig<'a, Self::Identity, Self::Certificate>,
+    ) -> Result<Self::Connection> {
+        #[cfg(feature = "rust-tls")]
+        let stream = if config.is_secure() {
+            tls_connection(
+                *config.ip(),
+                config.host(),
+                config.port(),
+                config.identity(),
+                config.certificate(),
+                config.skip_cert_verification(),
+                alpn(),
+            )
+            .await
+        } else {
+            plain_connection(*config.ip(), config.host(), config.port()).await
+        };
+
+        #[cfg(not(feature = "rust-tls"))]
+        let stream = plain_connection(*config.ip(), config.host(), config.port()).await;
+
+        if let Err(e) = stream {
+            return Err(e);
+        }
+
+        let result = handshake(FuturesIo::new(stream.unwrap())).await;
+
+        let (sender, conn) = result.unwrap();
+
+        glommio::spawn_local(async move {
+            match conn.await
+            {
+                Ok(_) => (),
+                Err(_err) => {}
+            };
+        })
+        .detach();
+
+        Ok(BaseHttpConnection::new(sender))
+    }
+}

--- a/deboa-glommio/src/client/http/http2.rs
+++ b/deboa-glommio/src/client/http/http2.rs
@@ -1,0 +1,81 @@
+#[cfg(feature = "rust-tls")]
+use crate::alpn;
+#[cfg(feature = "rust-tls")]
+use crate::client::http::conn::stream::tls_connection;
+use crate::{
+    cert::{DeboaCertificate, DeboaIdentity},
+    client::http::conn::{stream::plain_connection, BaseHttpConnection, Http2Connection},
+    rt::executor::GlommioExecutor,
+};
+use deboa::{
+    conn::{ConnectionConfig, HttpConnection, ProtoConnection},
+    request::Http2Request,
+    Result,
+};
+use http::version::Version;
+use hyper::client::conn::http2::handshake;
+use hyper_body_utils::HttpBody;
+use smol_hyper::rt::FuturesIo;
+
+impl HttpConnection for Http2Connection {
+    type Sender = Http2Request;
+    fn sender(&mut self) -> &mut Self::Sender {
+        &mut self.sender
+    }
+}
+
+impl ProtoConnection for Http2Connection {
+    type ReqBody = HttpBody;
+    type ResBody = HttpBody;
+    type Connection = Http2Connection;
+    type Identity = DeboaIdentity;
+    type Certificate = DeboaCertificate;
+
+    #[inline]
+    fn protocol_version(&self) -> Version {
+        Version::HTTP_2
+    }
+
+    async fn connect<'a>(
+        config: &ConnectionConfig<'a, Self::Identity, Self::Certificate>,
+    ) -> Result<Self::Connection> {
+        #[cfg(feature = "rust-tls")]
+        let stream = if config.is_secure() {
+            tls_connection(
+                *config.ip(),
+                config.host(),
+                config.port(),
+                config.identity(),
+                config.certificate(),
+                config.skip_cert_verification(),
+                alpn(),
+            )
+            .await
+        } else {
+            plain_connection(*config.ip(), config.host(), config.port()).await
+        };
+
+        #[cfg(not(feature = "rust-tls"))]
+        let stream = plain_connection(*config.ip(), config.host(), config.port()).await;
+
+        if let Err(e) = stream {
+            return Err(e);
+        }
+
+        let result = handshake(GlommioExecutor::new(), FuturesIo::new(stream.unwrap())).await;
+
+        let (sender, conn) = result.unwrap();
+
+        glommio::spawn_local(async move {
+            match conn.await {
+                Ok(_) => (),
+                Err(err) => {
+                    log::debug!("http2 connection ended: {err:#}");
+                }
+            };
+        })
+        .detach();
+
+        Ok(BaseHttpConnection::new(sender))
+    }
+}

--- a/deboa-glommio/src/client/http/mod.rs
+++ b/deboa-glommio/src/client/http/mod.rs
@@ -1,0 +1,13 @@
+//! Core HTTP client implementation for Deboa.
+//!
+//! This module provides the main HTTP client functionality, including connection management
+//! and request/response handling. It's the central component for making HTTP requests
+//! in the Deboa library.
+
+/// Connection management functionality for the Deboa HTTP client.
+pub mod conn;
+
+#[cfg(feature = "http1")]
+pub(crate) mod http1;
+#[cfg(feature = "http2")]
+pub(crate) mod http2;

--- a/deboa-glommio/src/client/mod.rs
+++ b/deboa-glommio/src/client/mod.rs
@@ -1,0 +1,5 @@
+/// DNS resolution for the Deboa HTTP client.
+///
+/// This module provides DNS resolution functionality for the Deboa HTTP client.pub(crate) mod dns;
+pub mod dns;
+pub mod http;

--- a/deboa-glommio/src/lib.rs
+++ b/deboa-glommio/src/lib.rs
@@ -1,0 +1,90 @@
+#![doc = include_str!("../README.md")]
+#![deny(missing_docs)]
+#[cfg(all(
+    feature = "rust-tls",
+    not(feature = "native-tls",),
+    not(all(
+        any(
+            feature = "no-provider",
+            feature = "default-rustls-provider",
+            feature = "aws-lc-rustls-provider",
+            feature = "ring-rustls-provider",
+        ),
+        any(
+            feature = "default-rustls-verifier",
+            feature = "webpki-rustls-verifier",
+            feature = "platform-rustls-verifier"
+        )
+    ))
+))]
+compile_error!(
+    "When enabling rust-tls features, you must also enable default-rustls-provider and default-rustls-verifier features."
+);
+
+#[cfg(feature = "native-tls")]
+compile_error!(
+    "deboa-glommio does not support native-tls: `async-native-tls` picks its runtime by feature \
+     (runtime-tokio / runtime-smol) and has no glommio binding. Use the rust-tls feature."
+);
+
+#[cfg(feature = "http3")]
+compile_error!(
+    "deboa-glommio does not support HTTP/3 yet: it needs a `quinn::Runtime` implementation for \
+     glommio, which does not exist. Use http1 or http2."
+);
+
+#[cfg(feature = "websockets")]
+compile_error!("deboa-glommio does not support websockets yet.");
+
+#[cfg(not(any(feature = "http1", feature = "http2")))]
+compile_error!("At least one HTTP version feature must be enabled.");
+
+use deboa::InnerClient;
+
+use crate::{
+    cert::{DeboaCertificate, DeboaIdentity},
+    client::{dns::DefaultDnsResolver, http::conn::pool::HttpConnectionPool},
+};
+
+#[cfg(feature = "rust-tls")]
+#[inline]
+pub(crate) fn alpn() -> Vec<Vec<u8>> {
+    vec![
+        #[cfg(feature = "http2")]
+        b"h2".to_vec(),
+        #[cfg(feature = "http1")]
+        b"http/1.1".to_vec(),
+        #[cfg(feature = "http3")]
+        b"h3".to_vec(),
+    ]
+}
+
+#[cfg(feature = "native-tls")]
+#[inline]
+pub(crate) fn alpn() -> &'static [&'static str] {
+    &[
+        #[cfg(feature = "http2")]
+        "h2",
+        #[cfg(feature = "http1")]
+        "http/1.1",
+        #[cfg(feature = "http3")]
+        "h3",
+    ]
+}
+
+/// Certificate management module for handling SSL/TLS certificates.
+pub mod cert;
+/// Internal module for HTTP and Websockets clients implementations.
+pub mod client;
+/// Internal runtime module for Smol-based HTTP client implementation.
+pub(crate) mod rt;
+
+/// Inner client type with generic resolver.
+pub type RuntimeClient<Resolver> =
+    InnerClient<DeboaIdentity, DeboaCertificate, HttpConnectionPool, Resolver>;
+
+/// Type alias for the Tokio-based HTTP client.
+pub type Client = deboa::Client<RuntimeClient<DefaultDnsResolver>>;
+
+/// Type alias for the custom Tokio-based HTTP client.
+pub type CustomClient<Resolver> = deboa::Client<RuntimeClient<Resolver>>;

--- a/deboa-glommio/src/rt/executor.rs
+++ b/deboa-glommio/src/rt/executor.rs
@@ -1,0 +1,26 @@
+use hyper::rt::Executor;
+use std::future::Future;
+
+#[non_exhaustive]
+#[derive(Default, Debug, Clone)]
+pub(crate) struct GlommioExecutor {}
+
+// **No `Send` bound, and that is the whole point.** hyper's `Executor` trait
+// does not require one; the smol and tokio bindings add it because their
+// spawns do. glommio's `spawn_local` keeps the future on this core, so the
+// per-core binding can implement the same trait more permissively.
+impl<Fut> Executor<Fut> for GlommioExecutor
+where
+    Fut: Future + 'static,
+    Fut::Output: 'static,
+{
+    fn execute(&self, fut: Fut) {
+        glommio::spawn_local(fut).detach();
+    }
+}
+
+impl GlommioExecutor {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/deboa-glommio/src/rt/mod.rs
+++ b/deboa-glommio/src/rt/mod.rs
@@ -1,0 +1,26 @@
+//! # Runtime Abstraction Layer
+//!
+//! This module provides runtime-specific implementations for different async runtimes.
+//! It allows the library to work with multiple async runtimes through feature flags.
+//!
+//! ## Usage
+//!
+//! The appropriate runtime module will be automatically selected based on the enabled features.
+//! You don't need to interact with this module directly in most cases.
+//!
+//! ## Features
+//!
+//! Enable the corresponding feature in your `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies.deboa]
+//! version = "0.0.8"
+//! features = ["http1", "rust-tls"]
+//! ```
+
+/// Stream module for runtime-specific stream implementations.
+pub mod stream;
+
+/// Executor module for HTTP/2 operations
+#[cfg(feature = "http2")]
+pub(crate) mod executor;

--- a/deboa-glommio/src/rt/stream.rs
+++ b/deboa-glommio/src/rt/stream.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "native-tls")]
 use async_native_tls::TlsStream;
+use futures::io::{self, AsyncRead, AsyncWrite};
 #[cfg(feature = "rust-tls")]
 use futures_rustls::client::TlsStream;
-use futures::io::{self, AsyncRead, AsyncWrite};
 use glommio::net::TcpStream;
 use std::{
     pin::Pin,

--- a/deboa-glommio/src/rt/stream.rs
+++ b/deboa-glommio/src/rt/stream.rs
@@ -1,0 +1,88 @@
+#[cfg(feature = "native-tls")]
+use async_native_tls::TlsStream;
+#[cfg(feature = "rust-tls")]
+use futures_rustls::client::TlsStream;
+use futures::io::{self, AsyncRead, AsyncWrite};
+use glommio::net::TcpStream;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// A stream that can be either plain TCP or TLS-secured.
+pub(crate) enum GlommioStream {
+    /// A plain TCP connection.
+    Plain(TcpStream),
+
+    /// A TCP connection secured by native TLS.
+    #[cfg(feature = "native-tls")]
+    Tls(TlsStream<TcpStream>),
+
+    /// A TCP connection secured by rustls.
+    #[cfg(feature = "rust-tls")]
+    Tls(Box<TlsStream<TcpStream>>),
+}
+
+impl AsyncRead for GlommioStream {
+    /// Polls for reading data from the stream.
+    ///
+    /// # Arguments
+    ///
+    /// * `cx` - The context to use for polling.
+    /// * `buf` - The buffer to read data into.
+    ///
+    /// # Returns
+    ///
+    /// * `Poll<io::Result<usize>>` - The result of the read operation.
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            GlommioStream::Plain(stream) => Pin::new(stream).poll_read(cx, buf),
+            #[cfg(any(feature = "native-tls", feature = "rust-tls"))]
+            GlommioStream::Tls(stream) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for GlommioStream {
+    /// Polls for writing data to the stream.
+    ///
+    /// # Arguments
+    ///
+    /// * `cx` - The context to use for polling.
+    /// * `buf` - The buffer to write data from.
+    ///
+    /// # Returns
+    ///
+    /// * `Poll<io::Result<usize>>` - The result of the write operation.
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut *self {
+            GlommioStream::Plain(stream) => Pin::new(stream).poll_write(cx, buf),
+            #[cfg(any(feature = "native-tls", feature = "rust-tls"))]
+            GlommioStream::Tls(stream) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut *self {
+            GlommioStream::Plain(stream) => Pin::new(stream).poll_close(cx),
+            #[cfg(any(feature = "native-tls", feature = "rust-tls"))]
+            GlommioStream::Tls(stream) => Pin::new(stream).poll_close(cx),
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut *self {
+            GlommioStream::Plain(stream) => Pin::new(stream).poll_flush(cx),
+            #[cfg(any(feature = "native-tls", feature = "rust-tls"))]
+            GlommioStream::Tls(stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+}

--- a/deboa-glommio/tests/round_trip.rs
+++ b/deboa-glommio/tests/round_trip.rs
@@ -1,0 +1,89 @@
+//! End-to-end: a hyper server and a deboa client, both on one glommio executor.
+//!
+//! Self-contained on purpose. The other bindings test against
+//! `easyhttpmock-vetis-*`, which is published per runtime and has no glommio
+//! build; standing the server up by hand here keeps the test hermetic and, as
+//! a side effect, proves both halves work on the same single-threaded core.
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+
+use deboa::request::{get, FetchWith};
+use deboa_glommio::Client;
+use http_body_util::Full;
+use hyper::body::Bytes;
+
+/// hyper needs its own I/O traits; glommio's `TcpStream` speaks `futures-io`.
+/// `smol_hyper`'s adapter bridges the two and pulls in no runtime of its own —
+/// the same one the client uses internally.
+fn serve(addr: SocketAddr, body: &'static str) {
+    let listener = glommio::net::TcpListener::bind(addr).expect("bind");
+    glommio::spawn_local(async move {
+        while let Ok(stream) = listener.accept().await {
+            glommio::spawn_local(async move {
+                let service = hyper::service::service_fn(move |_req| async move {
+                    Ok::<_, Infallible>(hyper::Response::new(Full::new(Bytes::from(body))))
+                });
+                let _ = hyper::server::conn::http1::Builder::new()
+                    .serve_connection(smol_hyper::rt::FuturesIo::new(stream), service)
+                    .await;
+            })
+            .detach();
+        }
+    })
+    .detach();
+}
+
+/// A free port, bound and released so the server can take it.
+fn ephemeral_addr() -> SocketAddr {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+    listener.local_addr().expect("local_addr")
+}
+
+#[test]
+fn a_request_round_trips_on_a_local_executor() {
+    let addr = ephemeral_addr();
+
+    glommio::LocalExecutorBuilder::default()
+        .make()
+        .expect("build glommio executor")
+        .run(async move {
+            serve(addr, "hello from glommio");
+
+            let client = Client::default();
+            let response = get(format!("http://{addr}/").as_str())
+                .expect("build request")
+                .version(http::Version::HTTP_11)
+                .send_with(&client)
+                .await
+                .expect("request failed");
+
+            assert_eq!(response.status(), http::StatusCode::OK);
+        });
+}
+
+/// The pool is the reason a second request is cheaper than the first; this
+/// asserts it at least does not *break* the second request, which is the
+/// failure a naive pool produces (a connection handed back mid-body).
+#[test]
+fn two_requests_reuse_the_connection() {
+    let addr = ephemeral_addr();
+
+    glommio::LocalExecutorBuilder::default()
+        .make()
+        .expect("build glommio executor")
+        .run(async move {
+            serve(addr, "second");
+
+            let client = Client::default();
+            for _ in 0..2 {
+                let response = get(format!("http://{addr}/").as_str())
+                    .expect("build request")
+                    .version(http::Version::HTTP_11)
+                    .send_with(&client)
+                    .await
+                    .expect("request failed");
+                assert_eq!(response.status(), http::StatusCode::OK);
+            }
+        });
+}

--- a/deboa-glommio/tests/round_trip.rs
+++ b/deboa-glommio/tests/round_trip.rs
@@ -19,7 +19,10 @@ use hyper::body::Bytes;
 fn serve(addr: SocketAddr, body: &'static str) {
     let listener = glommio::net::TcpListener::bind(addr).expect("bind");
     glommio::spawn_local(async move {
-        while let Ok(stream) = listener.accept().await {
+        while let Ok(stream) = listener
+            .accept()
+            .await
+        {
             glommio::spawn_local(async move {
                 let service = hyper::service::service_fn(move |_req| async move {
                     Ok::<_, Infallible>(hyper::Response::new(Full::new(Bytes::from(body))))
@@ -37,7 +40,9 @@ fn serve(addr: SocketAddr, body: &'static str) {
 /// A free port, bound and released so the server can take it.
 fn ephemeral_addr() -> SocketAddr {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-    listener.local_addr().expect("local_addr")
+    listener
+        .local_addr()
+        .expect("local_addr")
 }
 
 #[test]

--- a/deboa-smol/src/client/dns.rs
+++ b/deboa-smol/src/client/dns.rs
@@ -1,5 +1,5 @@
 use deboa::{
-    dns::{DnsResolver, DnsResolverFuture},
+    dns::DnsResolver,
     errors::{DeboaError::Dns, DnsError},
 };
 use rand::seq::SliceRandom;
@@ -11,22 +11,19 @@ use std::net::IpAddr;
 pub struct DefaultDnsResolver;
 
 impl DnsResolver for DefaultDnsResolver {
-    fn resolve(&self, host: String, port: u16) -> DnsResolverFuture {
-        let future = async move {
-            let hostname = format!("{}:{}", host, port);
-            let addrs = resolve(hostname).await;
-            if let Err(e) = addrs {
-                return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
-            };
-
-            let mut ips: Vec<IpAddr> = addrs
-                .unwrap()
-                .into_iter()
-                .map(|addr| addr.ip())
-                .collect();
-            ips.shuffle(&mut rand::rng());
-            Ok(ips)
+    async fn resolve(&self, host: String, port: u16) -> deboa::Result<Vec<IpAddr>> {
+        let hostname = format!("{}:{}", host, port);
+        let addrs = resolve(hostname).await;
+        if let Err(e) = addrs {
+            return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
         };
-        Box::pin(future)
+
+        let mut ips: Vec<IpAddr> = addrs
+            .unwrap()
+            .into_iter()
+            .map(|addr| addr.ip())
+            .collect();
+        ips.shuffle(&mut rand::rng());
+        Ok(ips)
     }
 }

--- a/deboa-tokio/src/client/dns.rs
+++ b/deboa-tokio/src/client/dns.rs
@@ -1,5 +1,5 @@
 use deboa::{
-    dns::{DnsResolver, DnsResolverFuture},
+    dns::DnsResolver,
     errors::{DeboaError::Dns, DnsError},
 };
 use rand::seq::SliceRandom;
@@ -11,21 +11,18 @@ use tokio::net::lookup_host;
 pub struct DefaultDnsResolver;
 
 impl DnsResolver for DefaultDnsResolver {
-    fn resolve(&self, host: String, port: u16) -> DnsResolverFuture {
-        let future = async move {
-            let hostname = format!("{}:{}", host, port);
-            let addrs = lookup_host(hostname).await;
-            if let Err(e) = addrs {
-                return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
-            }
+    async fn resolve(&self, host: String, port: u16) -> deboa::Result<Vec<IpAddr>> {
+        let hostname = format!("{}:{}", host, port);
+        let addrs = lookup_host(hostname).await;
+        if let Err(e) = addrs {
+            return Err(Dns(DnsError::Resolve { host, message: e.to_string() }));
+        }
 
-            let mut ips: Vec<IpAddr> = addrs
-                .unwrap()
-                .map(|addr| addr.ip())
-                .collect();
-            ips.shuffle(&mut rand::rng());
-            Ok(ips)
-        };
-        Box::pin(future)
+        let mut ips: Vec<IpAddr> = addrs
+            .unwrap()
+            .map(|addr| addr.ip())
+            .collect();
+        ips.shuffle(&mut rand::rng());
+        Ok(ips)
     }
 }

--- a/deboa/src/dns.rs
+++ b/deboa/src/dns.rs
@@ -2,13 +2,24 @@
 //!
 //! This module provides functionality for resolving hostnames to IP addresses.
 use crate::Result;
-use std::{future::Future, net::IpAddr, pin::Pin};
-
-/// Type alias for DNS resolution future
-pub type DnsResolverFuture = Pin<Box<dyn Future<Output = Result<Vec<IpAddr>>> + Send>>;
+use std::{future::Future, net::IpAddr};
 
 /// DNS resolver trait for resolving hostnames to IP addresses.
+///
+/// The returned future is an associated type rather than a boxed
+/// `dyn Future + Send`, which is what it used to be. Two reasons:
+///
+/// - **`Send` was more than a resolver can promise on every runtime.**
+///   `getaddrinfo` blocks, so a resolver hands it to a thread pool — and where
+///   that pool's handle is itself `!Send`, as glommio's is, the boxed `Send`
+///   future was unimplementable. compio's `spawn_blocking` returns a `Send`
+///   future and satisfied it; glommio's does not, and had to pull in a second
+///   thread pool to work around a bound it could not meet.
+/// - It removes an allocation per lookup, which matters less but is free here.
+///
+/// `impl Future` in trait position matches the style the connection traits in
+/// [`crate::conn`] already use.
 pub trait DnsResolver: Send + Sync + 'static {
     /// Resolves a hostname to a list of IP addresses.
-    fn resolve(&self, host: String, port: u16) -> DnsResolverFuture;
+    fn resolve(&self, host: String, port: u16) -> impl Future<Output = Result<Vec<IpAddr>>>;
 }


### PR DESCRIPTION
## What

Adds `deboa-glommio`, a binding for the [glommio](https://github.com/DataDog/glommio)
runtime — thread-per-core, `io_uring`-backed, and single-threaded by
construction. Its sockets and tasks are `!Send`, so a client built on it never
leaves the core that opened its connections.

## Why it fits without changing the core

`deboa::conn`'s traits — `HttpConnection`, `HttpConnectionPool`,
`HttpConnectionDispatcher`, `ProtoConnection` — use `impl Future` in trait
position and carry no `Send`/`Sync`/`'static` bounds, so the binding implements
them as written. Not one line of `deboa` needed to change. That is a nice
property of the design and I don't think it is an accident, given
`deboa-compio` got there first.

The one place the `Send` shape shows through is DNS — see the caveat below,
which I have deliberately **not** fixed in this PR.

## The port

Ported from `deboa-smol`, since the two are structurally the same:

- **`rt/stream.rs`** — glommio's `TcpStream` already implements
  `futures::io::{AsyncRead, AsyncWrite}`, so the plain/TLS enum carried over
  unchanged apart from the type.
- **`rt/executor.rs`** — `glommio::spawn_local` instead of `smol::spawn`, and
  the `Executor` impl **drops the `Send` bound**: hyper's trait does not require
  one, the other bindings add it because their spawns do.
- **`client/http/{http1,http2}.rs`** — the same one-line spawn change.
  `smol_hyper::rt::FuturesIo` is reused as-is; it is generic over `futures-io`
  and pulls in no runtime. (Happy to vendor a copy if depending on a
  `smol-`prefixed crate from the glommio binding reads oddly.)
- **`client/http/conn/stream/plain.rs`** — dial through `glommio::net::TcpStream`.
- **`cert.rs`** — certificates load with `std::fs::read`; that path is
  startup-time, and glommio's file I/O is `io_uring`-specific with different
  open semantics.

## Scope

**Supported:** HTTP/1.1, HTTP/2, `rust-tls`, connection pooling, and the shared
request/response surface.

**Not supported**, each declared as a feature that fails with an explicit
`compile_error!` rather than a wall of type errors:

- `native-tls` — `async-native-tls` selects its runtime by feature
  (`runtime-tokio` / `runtime-smol`) and has no glommio binding.
- `http3` — needs a `quinn::Runtime` implementation for glommio.
- `websockets` — not ported yet.

Tell me if you would rather those be absent entirely than present-and-erroring;
I went this way so the failure explains itself.

## Testing

`easyhttpmock-vetis-*` is published per runtime and has no glommio build, so
`tests/round_trip.rs` is self-contained: it stands a hyper server up on the same
executor as the client. As a side effect that also demonstrates both halves
working on one single-threaded core.

Verified by hand as well:

| | |
|---|---|
| HTTP/1.1 plain, local server | 200 OK |
| HTTP/1.1 + TLS, `https://example.com` | 200 OK |
| HTTP/2 + TLS (ALPN h2), `https://example.com` | 200 OK |

## The caveat: DNS, and a question

`deboa::dns::DnsResolverFuture` is `Pin<Box<dyn Future + Send>>`.

glommio's `spawn_blocking` returns a handle bound to its local executor and is
therefore `!Send`, so this binding **cannot** use its runtime's own blocking
pool the way `deboa-compio` uses compio's — compio's `spawn_blocking`
dispatches to a thread pool and yields a `Send` future, which is why that
binding gets it for free.

What this PR ships instead: the runtime-agnostic
[`blocking`](https://crates.io/crates/blocking) crate, whose `unblock` yields a
`Send` future and fits the trait as written. It works, and it is the honest
option available today — but it means an extra thread pool alongside glommio's
own, which is a slightly odd thing for a thread-per-core binding to carry.

**If `DnsResolverFuture` lost its `Send` bound**, or became an associated type
on `DnsResolver`, this would become `glommio::executor().spawn_blocking(..)` and
the extra pool would go away. A `Send` future satisfies a `?Send` box, so the
change should cost the tokio, smol and compio bindings nothing.

I have kept that out of this PR deliberately — it touches the core and is your
call, not mine. Glad to send it separately if you want it, or to leave the
`blocking` approach as-is.

---

Happy to split this differently, rename things to match your conventions, or
add benchmarks alongside the other runtimes if that is expected of a new
binding.
