### PR TITLE
chore(glommio): bump glommio-ng to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,9 +1864,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glommio-ng"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6c9b99577dfaf726e575122b026fef3b57e2c39f03ae042460fdb5be7a1cc8"
+checksum = "95bccf930e7b78d67c6466cb1e585c6045da72b5e39c79d56bef2e5a8b3e4511"
 dependencies = [
  "ahash",
  "backtrace",
@@ -1874,12 +1874,12 @@ dependencies = [
  "bitflags 2.13.1",
  "bitmaps",
  "buddy-alloc",
- "cc",
  "concurrent-queue",
  "crossbeam",
  "enclose",
  "flume",
  "futures-lite",
+ "glommio-ng-macros",
  "intrusive-collections",
  "io-uring",
  "lazy_static",
@@ -1897,6 +1897,17 @@ dependencies = [
  "socket2",
  "tracing",
  "typenum",
+]
+
+[[package]]
+name = "glommio-ng-macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba7f0ed3085a23dcb1c888e8962f7f39a7a15bf893753842c573355e99b15b0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/deboa-glommio/Cargo.toml
+++ b/deboa-glommio/Cargo.toml
@@ -60,7 +60,7 @@ futures-rustls = { version = "0.26.0", optional = true, default-features = false
 # The canonical `glommio` crate is stuck at 0.9.0 (March 2024) and its vendored
 # liburing no longer compiles against current kernel headers. Renamed back to
 # `glommio` here so the source reads normally; see this crate's README.
-glommio = { package = "glommio-ng", version = "0.10" }
+glommio = { package = "glommio-ng", version = "0.11" }
 hashbrown = "0.17.1"
 http = "1"
 http-body = "1"


### PR DESCRIPTION
`glommio-ng` 0.11 makes `GlommioError` `Send + Sync`, which it wasn't before.

`BuilderErrorKind::ThreadPanic` held a `Box<dyn Any + Send>` — inherently `!Sync` — and that one variant made the whole error type `!Sync`, including the `GlommioError<()>` that every socket operation returns. Since `anyhow::Error` requires `Send + Sync + 'static`, a glommio error couldn't be `?`'d into anyhow by anyone downstream. 0.11 stores the panic message as a `String` instead, so it's `Sync` now and `Display` actually prints the message rather than a bare "thread panicked".

Nothing in `deboa-glommio` needed changing — it builds, clippy is clean, and the tests pass unchanged. The version requirement has to move because 0.x minor bumps are semver-major, so `^0.10` won't pick 0.11 up on its own.

Happy to hold this if you'd rather not move until there's a reason to; it's only needed by consumers who pair deboa-glommio with their own glommio, where two versions in one binary means two reactors and a runtime panic.