### PR TITLE
fix(tests): ask the OS for a port instead of guessing one

### DIFF
--- a/deboa-compio/tests/common/helpers.rs
+++ b/deboa-compio/tests/common/helpers.rs
@@ -4,7 +4,6 @@ use deboa_compio::{cert::DeboaCertificate, Client};
 use deboa_test_utils::common::helpers::{CA_CERT, SERVER_CERT, SERVER_KEY};
 use easyhttpmock_vetis_compio::{
     config::EasyHttpMockConfig,
-    server::PortGenerator,
     vetis_adapter::{VetisAdapter, VetisAdapterConfig},
     EasyHttpMock,
 };
@@ -74,7 +73,7 @@ pub async fn tls_mock_server() -> EasyHttpMock<VetisAdapter> {
         .hostname(&hostname)
         .interface(&interface)
         .protocol_version(protocol_version())
-        .with_random_port()
+        .port(free_port(&interface))
         .cert(server_cert.to_vec())
         .key(server_key.to_vec())
         .ca(CA_CERT.to_vec())
@@ -104,7 +103,7 @@ pub async fn plain_mock_server() -> EasyHttpMock<VetisAdapter> {
         .hostname(&hostname)
         .interface(&interface)
         .protocol_version(protocol_version())
-        .with_random_port()
+        .port(free_port(&interface))
         .build();
 
     let config = EasyHttpMockConfig::<VetisAdapter>::builder()
@@ -128,4 +127,27 @@ pub async fn create_server() -> EasyHttpMock<VetisAdapter> {
     return tls_mock_server().await;
     #[cfg(not(any(feature = "rust-tls", feature = "native-tls")))]
     return plain_mock_server().await;
+}
+
+/// An ephemeral port the OS says is free, rather than a guessed one.
+///
+/// `with_random_port()` picks `rand::random_range(9000..65535)` and
+/// de-duplicates against a process-local set. Under `cargo test` that mostly
+/// holds, because every test shares one process and therefore one set. Under
+/// `cargo nextest run` — which is what CI uses — each test is its own process,
+/// so the set protects nothing and two tests eventually roll the same number.
+/// The loser dies with `Address already in use (os error 98)` before its body
+/// runs, which is why the failing test is a different one each time.
+///
+/// Binding port 0 asks the kernel for a port it knows is free. There is still a
+/// window between dropping this listener and the server binding, but the kernel
+/// will not hand the same ephemeral port to someone else inside it, which is
+/// the part guessing cannot promise.
+fn free_port(interface: &str) -> u16 {
+    let listener = std::net::TcpListener::bind((interface, 0))
+        .expect("bind an ephemeral port to ask the OS for a free one");
+    listener
+        .local_addr()
+        .expect("read back the bound port")
+        .port()
 }

--- a/deboa-smol/tests/common/helpers.rs
+++ b/deboa-smol/tests/common/helpers.rs
@@ -2,7 +2,6 @@ use deboa::cert::{CertificateExt as _, ContentEncoding};
 use deboa_smol::{cert::DeboaCertificate, Client};
 use easyhttpmock_vetis_smol::{
     config::EasyHttpMockConfig,
-    server::PortGenerator,
     vetis_adapter::{VetisAdapter, VetisAdapterConfig},
     EasyHttpMock,
 };
@@ -76,7 +75,7 @@ pub async fn tls_mock_server() -> EasyHttpMock<VetisAdapter> {
         .hostname(&hostname)
         .interface(&interface)
         .protocol_version(protocol_version())
-        .with_random_port()
+        .port(free_port(&interface))
         .cert(server_cert.to_vec())
         .key(server_key.to_vec())
         .ca(CA_CERT.to_vec())
@@ -106,7 +105,7 @@ pub async fn plain_mock_server() -> EasyHttpMock<VetisAdapter> {
         .hostname(&hostname)
         .interface(&interface)
         .protocol_version(protocol_version())
-        .with_random_port()
+        .port(free_port(&interface))
         .build();
 
     let config = EasyHttpMockConfig::<VetisAdapter>::builder()
@@ -130,4 +129,27 @@ pub async fn create_server() -> EasyHttpMock<VetisAdapter> {
     return tls_mock_server().await;
     #[cfg(not(any(feature = "rust-tls", feature = "native-tls")))]
     return plain_mock_server().await;
+}
+
+/// An ephemeral port the OS says is free, rather than a guessed one.
+///
+/// `with_random_port()` picks `rand::random_range(9000..65535)` and
+/// de-duplicates against a process-local set. Under `cargo test` that mostly
+/// holds, because every test shares one process and therefore one set. Under
+/// `cargo nextest run` — which is what CI uses — each test is its own process,
+/// so the set protects nothing and two tests eventually roll the same number.
+/// The loser dies with `Address already in use (os error 98)` before its body
+/// runs, which is why the failing test is a different one each time.
+///
+/// Binding port 0 asks the kernel for a port it knows is free. There is still a
+/// window between dropping this listener and the server binding, but the kernel
+/// will not hand the same ephemeral port to someone else inside it, which is
+/// the part guessing cannot promise.
+fn free_port(interface: &str) -> u16 {
+    let listener = std::net::TcpListener::bind((interface, 0))
+        .expect("bind an ephemeral port to ask the OS for a free one");
+    listener
+        .local_addr()
+        .expect("read back the bound port")
+        .port()
 }

--- a/deboa-tokio/tests/common/helpers.rs
+++ b/deboa-tokio/tests/common/helpers.rs
@@ -6,9 +6,7 @@ use deboa_test_utils::common::helpers::CA_CERT;
 use deboa_test_utils::common::helpers::{SERVER_CERT, SERVER_KEY};
 #[cfg(any(feature = "rust-tls", feature = "native-tls"))]
 use deboa_tokio::{cert::DeboaCertificate, Client};
-use easyhttpmock_vetis_tokio::{
-    config::EasyHttpMockConfig, server::PortGenerator as _, vetis_adapter::VetisAdapterConfig,
-};
+use easyhttpmock_vetis_tokio::{config::EasyHttpMockConfig, vetis_adapter::VetisAdapterConfig};
 use easyhttpmock_vetis_tokio::{vetis_adapter::VetisAdapter, EasyHttpMock};
 use http::Version;
 use rstest::fixture;
@@ -77,7 +75,7 @@ pub async fn tls_mock_server() -> EasyHttpMock<VetisAdapter> {
         .hostname(&hostname)
         .interface(&interface)
         .protocol_version(protocol_version())
-        .with_random_port()
+        .port(free_port(&interface))
         .cert(server_cert.to_vec())
         .key(server_key.to_vec())
         .ca(CA_CERT.to_vec())
@@ -107,7 +105,7 @@ pub async fn plain_mock_server() -> EasyHttpMock<VetisAdapter> {
         .hostname(&hostname)
         .interface(&interface)
         .protocol_version(protocol_version())
-        .with_random_port()
+        .port(free_port(&interface))
         .build();
 
     let config = EasyHttpMockConfig::<VetisAdapter>::builder()
@@ -131,4 +129,27 @@ pub async fn create_server() -> EasyHttpMock<VetisAdapter> {
     return tls_mock_server().await;
     #[cfg(not(any(feature = "rust-tls", feature = "native-tls")))]
     return plain_mock_server().await;
+}
+
+/// An ephemeral port the OS says is free, rather than a guessed one.
+///
+/// `with_random_port()` picks `rand::random_range(9000..65535)` and
+/// de-duplicates against a process-local set. Under `cargo test` that mostly
+/// holds, because every test shares one process and therefore one set. Under
+/// `cargo nextest run` — which is what CI uses — each test is its own process,
+/// so the set protects nothing and two tests eventually roll the same number.
+/// The loser dies with `Address already in use (os error 98)` before its body
+/// runs, which is why the failing test is a different one each time.
+///
+/// Binding port 0 asks the kernel for a port it knows is free. There is still a
+/// window between dropping this listener and the server binding, but the kernel
+/// will not hand the same ephemeral port to someone else inside it, which is
+/// the part guessing cannot promise.
+fn free_port(interface: &str) -> u16 {
+    let listener = std::net::TcpListener::bind((interface, 0))
+        .expect("bind an ephemeral port to ask the OS for a free one");
+    listener
+        .local_addr()
+        .expect("read back the bound port")
+        .port()
 }


### PR DESCRIPTION
CI has been failing on every PR for a while, and I think this is why. The failing test is a different one each run — I've seen `base::get::test_get_not_found`, `vamo::test_delete` and `deboa_macros::patch::test_only_patch_minimal_headers` — but underneath it's always:

```
Error: Server(Start("Failed to bind to address: Address already in use (os error 98)"))
```

`with_random_port()` picks `rand::random_range(9000..65535)` and checks it against a process-local set (easyhttpmock-0.1.3/src/server.rs:105). That mostly works under `cargo test`, where every test shares one process and therefore one set. CI runs `cargo nextest`, which gives each test its own process, so the set doesn't help and two tests eventually pick the same number. Whichever one loses dies before its body runs, which is why the failing test usually has nothing to do with the change being tested — the renovate glommio bump in #272 looks guilty but hasn't touched anything involved.

Binding port 0 lets the kernel pick something it knows is free. There's still a gap between dropping the probe listener and the server binding, but the kernel won't hand the same ephemeral port to another process during it, which is the bit guessing can't promise.

It was about one run in three for me. After this, 10 runs of deboa-compio and 5 each of deboa-smol and deboa-tokio came back clean.

This probably wants fixing properly in easyhttpmock — a per-process set can't work across processes however it's locked — but this keeps CI honest in the meantime. Happy to raise it there too if you'd like.